### PR TITLE
Improving tests

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -234,16 +234,25 @@ class TestCharm(unittest.TestCase):
         expected = "-config.file=/etc/agent/agent.yaml -prometheus.wal-directory=/tmp/agent/data"
         self.assertEqual(self.harness.charm._cli_args(), expected)
 
-    def test__loki_config_empty(self):
-        self.harness.charm._stored.remove_loki_config = True
-        self.assertEqual(self.harness.charm._loki_config(), {})
-
-        self.harness.charm._stored.remove_loki_config = False
-        self.assertEqual(self.harness.charm._loki_config(), {})
-
-    def test__loki_config_non_empty(self):
+    @responses.activate
+    @patch.object(Container, "pull", new=pull_empty_fake_file)
+    @patch.object(Container, "push")
+    def test__on_logging_relation_changed(self, mock_push: MagicMock):
         self.harness.charm._loki_consumer = Mock()
         self.harness.charm._loki_consumer.loki_push_api = "http://loki:3100:/loki/api/v1/push"
+        mock_push.push.return_value = None
+
+        responses.add(
+            responses.POST,
+            "http://localhost/-/reload",
+            status=200,
+        )
+
+        rel_id = self.harness.add_relation("logging", "consumer")
+        self.harness.add_relation_unit(rel_id, "consumer/0")
+        self.harness.update_relation_data(rel_id, "consumer/0", {})
+
+        path, content = mock_push.call_args[0]
 
         expected = {
             "configs": [
@@ -267,63 +276,33 @@ class TestCharm(unittest.TestCase):
             ]
         }
 
-        self.assertDictEqual(self.harness.charm._loki_config(), expected)
+        self.assertDictEqual(yaml.safe_load(content)["loki"], expected)
+        self.assertEqual(path, "/etc/agent/agent.yaml")
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    def test__config_file_without_loki(self):
-        self.maxDiff = None
-        expected = {
-            "integrations": {
-                "agent": {
-                    "enabled": True,
-                    "relabel_configs": REWRITE_CONFIGS,
-                },
-                "prometheus_remote_write": [],
-            },
-            "prometheus": {
-                "configs": [{"name": "agent_scraper", "remote_write": [], "scrape_configs": []}]
-            },
-            "server": {"log_level": "info"},
-        }
-        self.assertDictEqual(yaml.safe_load(self.harness.charm._config_file()), expected)
-
-    def test__config_file_with_loki(self):
+    @responses.activate
+    @patch.object(Container, "pull", new=pull_empty_fake_file)
+    @patch.object(Container, "push")
+    def test__on_logging_relation_departed(self, mock_push: MagicMock):
         self.harness.charm._loki_consumer = Mock()
         self.harness.charm._loki_consumer.loki_push_api = "http://loki:3100:/loki/api/v1/push"
-        expected = {
-            "integrations": {
-                "agent": {
-                    "enabled": True,
-                    "relabel_configs": REWRITE_CONFIGS,
-                },
-                "prometheus_remote_write": [],
-            },
-            "prometheus": {
-                "configs": [{"name": "agent_scraper", "remote_write": [], "scrape_configs": []}]
-            },
-            "server": {"log_level": "info"},
-            "loki": {
-                "configs": [
-                    {
-                        "name": "promtail",
-                        "clients": [{"url": "http://loki:3100:/loki/api/v1/push"}],
-                        "positions": {"filename": "/tmp/positions.yaml"},
-                        "scrape_configs": [
-                            {
-                                "job_name": "loki",
-                                "loki_push_api": {
-                                    "server": {
-                                        "http_listen_port": 3500,
-                                        "grpc_listen_port": 3600,
-                                    },
-                                    "labels": {"pushserver": "loki"},
-                                },
-                            }
-                        ],
-                    }
-                ]
-            },
-        }
-        self.assertDictEqual(expected, yaml.safe_load(self.harness.charm._config_file()))
+        mock_push.push.return_value = None
+
+        responses.add(
+            responses.POST,
+            "http://localhost/-/reload",
+            status=200,
+        )
+
+        rel_id = self.harness.add_relation("logging", "consumer")
+        self.harness.add_relation_unit(rel_id, "consumer/0")
+        self.harness.update_relation_data(rel_id, "consumer/0", {})
+        self.harness.remove_relation_unit(rel_id, "consumer/0")
+
+        path, content = mock_push.call_args[0]
+
+        self.assertTrue("loki" not in yaml.safe_load(content))
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     def test__update_config_pebble_not_ready(self):
         self.harness.charm._container.can_connect = Mock(return_value=False)

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ deps =
 commands =
     coverage run \
       --source={[vars]src_path} \
-      -m pytest -v --tb native {posargs} {[vars]test_path}/unit
+      -m pytest -v -s --tb native {posargs} {[vars]test_path}/unit
     coverage report -m --include=src/*.py
 
 [testenv:integration]


### PR DESCRIPTION
This PR fixes:
- Loki tests follows the same pattern used for Prometheus
- `test_remote_write_configuration` was broken. Sometimes returned green and sometimes red because of lists inside dictionaries
- Add `-s` parameter in pytest execution 

Related to OP-370