### PR TITLE
Split bases

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,6 +11,11 @@ bases:
     - name: "ubuntu"
       channel: "22.04"
       architectures: ["amd64"]
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+      architectures: ["amd64"]
+    run-on:
     - name: "ubuntu"
       channel: "20.04"
       architectures: ["amd64"]

--- a/tests/integration/test_juju_info.py
+++ b/tests/integration/test_juju_info.py
@@ -40,9 +40,16 @@ async def test_build_and_deploy(ops_test: OpsTest, grafana_agent_charm):
     await ops_test.model.deploy(
         principal.charm, application_name=principal.name, num_units=2, series="jammy"
     )
+
+    # Workaround: `charmcraft pack` produces two files, but `ops_test.build_charm` returns the
+    # first one. Since primary is jammy, we know we need to deploy the jammy grafana agent charm,
+    # otherwise we'd get an error such as:
+    #   ImportError: libssl.so.1.1: cannot open shared object file: No such file or directory
+    jammy_charm_path = grafana_agent_charm.parent / "grafana-agent_ubuntu-22.04-amd64.charm"
+
     # Subordinate
     await ops_test.model.deploy(
-        grafana_agent_charm, application_name=agent.name, num_units=0, series="jammy"
+        jammy_charm_path, application_name=agent.name, num_units=0, series="jammy"
     )
 
     # Placeholder for o11y relations (otherwise grafana agent charm is in blocked status)

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,9 @@ deps =
     juju ~= 3.1.0
     pytest
     prometheus-api-client
-    pytest-operator
+    #pytest-operator
+    # https://github.com/charmed-kubernetes/pytest-operator/pull/115
+    pytest-operator @ git+https://github.com/sed-i/pytest-operator@patch-1
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/integration
 


### PR DESCRIPTION
## Issue
A 22.04-built charm fails on 20.04.


## Solution
Split bases, so there's a 1:1 match between build-on and run-on.

Fixes #5.
FIxes #6.

Depends on:
- https://github.com/charmed-kubernetes/pytest-operator/pull/115


## Context
Even though charmhub doesn't display the full context correctly yet, if we upload two revisions for two different bases, juju will be able to pick the correct one.
- https://github.com/canonical/charmcraft/issues/1263#issuecomment-1747811709

Note that our current CI does not support multiple *.charm files. Planning to do release manually for now.