### PR TITLE
Add rootfs_path to grafana-agent.yaml

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -392,6 +392,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         )
         return {
             "node_exporter": {
+                "rootfs_path": "/var/lib/snapd/hostfs",
                 "enabled": True,
                 "enable_collectors": [
                     "logind",


### PR DESCRIPTION
This ensures that the root fs data will be collected accurately,
since grafana-agent is running in a snap.

Fixes #22
