### PR TITLE
add config option for metrics.global.scrape_timeout

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ options:
       Loki).
     type: boolean
     default: false
-  scrape_timeout:
-    description: The global metrics scrape timeout.
-    type: string
-    default: "10s"
+  scrape-timeout-sec:
+    description: The global metrics scrape timeout (seconds).
+    type: int
+    default: 10

--- a/config.yaml
+++ b/config.yaml
@@ -10,3 +10,7 @@ options:
       Loki).
     type: boolean
     default: false
+  scrape_timeout:
+    description: The global metrics scrape timeout.
+    type: string
+    default: "10s"

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -650,6 +650,9 @@ class GrafanaAgentCharm(CharmBase):
             "integrations": self._integrations_config,
             "metrics": {
                 "wal_directory": "/tmp/agent/data",
+                "global": {
+                    "scrape_timeout": self.model.config.get("global_scrape_timeout"),
+                },
                 "configs": [
                     {
                         "name": "agent_scraper",


### PR DESCRIPTION
## Issue
Closes #14.


## Solution
Add the metrics scrape timeout as a Juju config option.