### PR TITLE
Recursively scrape logs in /var/log/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This documents explains the processes and practices recommended for
-contributing enhancements to the Loki charm.
+contributing enhancements to the Grafana Agent charm.
 
 - Generally, before developing enhancements to this charm, you should consider opening an issue explaining your use case.
 - If you would like to chat with us about your use-cases or proposed implementation, you can reach us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/lma) or [Discourse](https://discourse.charmhub.io/). The primary authors of this charm are available on the Mattermost channel as `@dylanstathis` and `@jose-masson`.

--- a/src/charm.py
+++ b/src/charm.py
@@ -438,7 +438,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                             {
                                 "targets": ["localhost"],
                                 "labels": {
-                                    "__path__": "/var/log/*log",
+                                    "__path__": "/var/log/**/*log",
                                     **self._principal_labels,
                                 },
                             }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fix #18 

## Solution
Currently no subdirectories of `/var/log` are scraped, which also means that juju logs placed in `/var/log/juju` are not sent to Loki. This PR fixes that by scraping `/var/log/**/*log`.


## Context
n/a


## Testing Instructions
Deploy the charm, integrate it properly, and watch for logs from `/var/log/juju/` to be sent.


## Release Notes
Recursively scrape the logs in `/var/log/` 
