### PR TITLE
fix scrape timeout config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ options:
       Loki).
     type: boolean
     default: false
-  scrape-timeout-sec:
-    description: The global metrics scrape timeout (seconds).
-    type: int
-    default: 10
+  global_scrape_timeout:
+    description: The global metrics scrape timeout.
+    type: string
+    default: "10s"


### PR DESCRIPTION
## Issue
The Juju config doesn't match the variable read from charm code.


## Solution
Bootstack mentioned a preference for the string config as it allows different units (e.g., `10s`, `1m`).