### PR TITLE
Update docs and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ juju add-model cos
 The Grafana agent may be deployed using the juju command line:
 
 ```bash
-juju deploy grafana-agent --trust
+juju deploy grafana-agent
 ```
 
 If required, you can remove the deployment completely:
@@ -47,27 +47,7 @@ juju destroy-model -y cos --no-wait --force --destroy-storage
 
 ## Relations
 
-Currently supported relations are:
-
-```yaml
-requires:
-  send-remote-write:
-    interface: prometheus_remote_write
-  metrics-endpoint:
-    interface: prometheus_scrape
-  logging-consumer:
-    interface: loki_push_api
-
-provides:
-  self-metrics-endpoint:
-    interface: prometheus_scrape
-  grafana-dashboard:
-    interface: grafana_dashboard
-  logging-provider:
-    interface: loki_push_api
-```
-
-More detailed information about these relations can be found in [Charmhub docs page](https://charmhub.io/grafana-agent/docs/relations).
+Detailed information about the relations can be found in [Charmhub integrations page](https://charmhub.io/grafana-agent/integrations).
 
 
 ## OCI Images

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,10 +17,10 @@ maintainers:
     - Luca Bello <luca.bello@canonical.com>
     - Simon Aronsson <simon.aronsson@canonical.com>
 
-#docs: https://discourse.charmhub.io/t/grafana-agent-k8s-docs-index/5605
+docs: https://github.com/canonical/grafana-agent-operator/blob/main/README.md
 website: https://charmhub.io/grafana-agent
-#source: https://github.com/canonical/grafana-agent-k8s-operator
-#issues: https://github.com/canonical/grafana-agent-k8s-operator/issues
+source: https://github.com/canonical/grafana-agent-operator
+issues: https://github.com/canonical/grafana-agent-operator/issues
 
 subordinate: true
 series:


### PR DESCRIPTION
These mainly fix things that seem to be leftovers from porting
from the grafana-agent-k8s-operator codebase.

Fixes: #16

Fixes: #21
