### PR TITLE
Change the expression of the oomkill.rule to use 1h

### DIFF
--- a/src/prometheus_alert_rules/oomkill.rule
+++ b/src/prometheus_alert_rules/oomkill.rule
@@ -1,5 +1,5 @@
 alert: HostOomKillDetected
-expr: increase(node_vmstat_oom_kill[1m]) > 0
+expr: increase(node_vmstat_oom_kill[1h]) > 0
 for: 0m
 labels:
   severity: warning


### PR DESCRIPTION
## Issue
Closes #50 

## Solution
Change the oomkill.rule expression to use 1h instead of 1m for the duration.


## Release Notes
Change the out of memory alert expression to use 1h instead of 1m for the duration.
