### PR TITLE
fix: cryptography issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ cosl
 ops > 2.5.0
 pydantic < 2
 requests
-cryptography
+cryptography == 42.0.1 # Pin prevents an error in the wheels due to crypto package moving to openssl 3.2.1
 jsonschema < 4  # Pin prevents the machine charm error "ModuleNotFoundError: No module named 'rpds.rpds'"


### PR DESCRIPTION
Pin cryptography version to the version prior to upstream changing the build dep of `openssl` to `3.2.1`. See https://cryptography.io/en/latest/changelog/#v42-0-2.