### PR TITLE
Add juju_charm label to logs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -416,6 +416,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                                 "targets": ["localhost"],
                                 "labels": {
                                     "__path__": "/var/log/**/*log",
+                                    "job": "varlog",
                                     **self._own_labels,
                                 },
                             }
@@ -423,7 +424,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                     },
                     {
                         "job_name": "syslog",
-                        "journal": {"labels": self._own_labels},
+                        "journal": {"labels": self._own_labels | {"job": "syslog"}},
                         "pipeline_stages": [
                             {
                                 "drop": {

--- a/src/charm.py
+++ b/src/charm.py
@@ -424,7 +424,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                     },
                     {
                         "job_name": "syslog",
-                        "journal": {"labels": self._own_labels | {"job": "syslog"}},
+                        "journal": {"labels": {**self._own_labels, **{"job": "syslog"}}},
                         "pipeline_stages": [
                             {
                                 "drop": {

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -771,6 +771,7 @@ class GrafanaAgentCharm(CharmBase):
             "juju_model_uuid": self.model.uuid,
             "juju_application": self.model.app.name,
             "juju_unit": self.model.unit.name,
+            "juju_charm": self.meta.name
         }
 
     @property

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -771,7 +771,7 @@ class GrafanaAgentCharm(CharmBase):
             "juju_model_uuid": self.model.uuid,
             "juju_application": self.model.app.name,
             "juju_unit": self.model.unit.name,
-            "juju_charm": self.meta.name
+            "juju_charm": self.meta.name,
         }
 
     @property


### PR DESCRIPTION
## Issue

Fix #55 


## Solution

Add the juju_charm and job label to fix alert rule matching.

Before

![image](https://github.com/canonical/grafana-agent-operator/assets/4182921/02b5b806-2595-477d-9716-c90812a17b67)

After

![image](https://github.com/canonical/grafana-agent-operator/assets/4182921/31393a81-43bb-4acd-a9f3-437c52b3ae5d)

Example alert rule

![image](https://github.com/canonical/grafana-agent-operator/assets/4182921/59ed5415-805c-456f-9d4a-70d927c37e01)



## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
n/a

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. `juju deploy github-runner` (or any compatible machine charm)
2. `juju integrate github-runner grafana-agent`
3. Make sure the logs contain the `juju_charm=grafana-agent` label so that the alert expressions are matched.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
