### PR TITLE
feat: pin snap revision, add metadata to control snaps

### DIFF
--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -13,7 +13,7 @@ Modified from https://github.com/canonical/k8s-operator/blob/main/charms/worker/
 import logging
 import subprocess
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import charms.operator_libs_linux.v2.snap as snap_lib
 import yaml
@@ -103,7 +103,7 @@ class SnapManifest:
         dpkg_arch = ["dpkg", "--print-architecture"]
         return subprocess.check_output(dpkg_arch).decode("UTF-8").strip()
 
-    def _get_parsed_manifest(self) -> dict[str, SnapArgument]:
+    def _get_parsed_manifest(self) -> Dict[str, SnapArgument]:
         """Loads and parses the manifest file.
 
         Raises:
@@ -115,7 +115,7 @@ class SnapManifest:
         manifest_raw = self._get_manifest()
         return self._parse_manifest(manifest_raw)
 
-    def _get_manifest(self) -> List[dict]:
+    def _get_manifest(self) -> List[Dict]:
         """Loads the snap manifest file, returning the manifest for this architecture.
 
         Raises:
@@ -140,10 +140,12 @@ class SnapManifest:
 
         return manifest_this_arch
 
-    def _parse_manifest(self, manifest: List[dict]) -> dict[str, SnapArgument]:
+    def _parse_manifest(self, manifest: List[Dict]) -> Dict[str, SnapArgument]:
         """Parses a manifest defined by a list of snap dicts, rendering them to SnapArguments."""
         try:
-            manifest_parsed = {arg["name"]: parse_obj_as(SnapArgument, arg) for arg in manifest}
+            manifest_parsed = {
+                arg["name"]: parse_obj_as(SnapArgument, arg) for arg in manifest  # pyright: ignore
+            }
         except (ValidationError, KeyError) as e:
             log.warning("Failed to validate args=%s (%s)", self.arch, e)
             raise SnapManifestError("Failed to validate snap args")

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Learn more at: https://juju.is/docs/sdk
+
+"""Snap Installation Module.
+
+Modified from https://github.com/canonical/k8s-operator/blob/main/charms/worker/k8s/src/snap.py
+"""
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import List, Literal, Optional, Union
+
+import charms.operator_libs_linux.v2.snap as snap_lib
+import yaml
+from pydantic import BaseModel, Field, ValidationError, parse_obj_as
+from typing_extensions import Annotated
+
+# Log messages can be retrieved using juju debug-log
+log = logging.getLogger(__name__)
+
+
+class SnapFileArgument(BaseModel):
+    """Structure to install a snap by file.
+
+    Attributes:
+        install_type (str): literal string defining this type
+        name (str): The name of the snap after installed
+        filename (Path): Path to the snap to locally install
+        classic (bool): If it should be installed as a classic snap
+        dangerous (bool): If it should be installed as a dangerouse snap
+        devmode (bool): If it should be installed as with dev mode enabled
+    """
+
+    install_type: Literal["file"] = Field("file", alias="install-type", exclude=True)
+    name: str = Field(exclude=True)
+    filename: Optional[Path] = None
+    classic: Optional[bool] = None
+    devmode: Optional[bool] = None
+    dangerous: Optional[bool] = None
+
+
+class SnapStoreArgument(BaseModel):
+    """Structure to install a snap by snapstore.
+
+    Attributes:
+        install_type (str): literal string defining this type
+        name (str): The type of the request.
+        state (SnapState): a `SnapState` to reconcile to.
+        classic (bool): If it should be installed as a classic snap
+        devmode (bool): If it should be installed as with dev mode enabled
+        channel (bool): the channel to install from
+        cohort (str): the key of a cohort that this snap belongs to
+        revision (str): the revision of the snap to install
+    """
+
+    install_type: Literal["store"] = Field("store", alias="install-type", exclude=True)
+    name: str = Field(exclude=True)
+    classic: Optional[bool] = None
+    devmode: Optional[bool] = None
+    state: Optional[snap_lib.SnapState] = Field(snap_lib.SnapState.Present)
+    channel: Optional[str] = None
+    cohort: Optional[str] = None
+    revision: Optional[str] = None
+
+
+SnapArgument = Annotated[
+    Union[SnapFileArgument, SnapStoreArgument], Field(discriminator="install_type")
+]
+
+
+class SnapManifestError(Exception):
+    """Base class for snap management errors."""
+
+    pass
+
+
+class SnapManifest:
+    """Manager for a manifest of snaps to install."""
+
+    def __init__(self, manifest_path: Union[Path, str], arch: Optional[str] = None):
+        """Initialize the snap manifest manager.
+
+        Args:
+            manifest_path: Path to the manifest file
+            arch: The architecture to use for snap installation.  If omitted, the system arch will
+                  be inferred.
+        """
+        if arch is None:
+            arch = self._get_system_arch()
+        self.arch = arch
+
+        self._manifest_path = Path(manifest_path)
+        self._manifest = self._get_parsed_manifest()
+
+    @staticmethod
+    def _get_system_arch():
+        """Returns the architecture of this machine, using dpkg."""
+        dpkg_arch = ["dpkg", "--print-architecture"]
+        return subprocess.check_output(dpkg_arch).decode("UTF-8").strip()
+
+    def _get_parsed_manifest(self) -> dict[str, SnapArgument]:
+        """Loads and parses the manifest file.
+
+        Raises:
+            SnapManifestError: when the manifest file cannot be loaded or parsed.
+
+        Returns:
+            A dict of SnapArguments keyed by their snap name
+        """
+        manifest_raw = self._get_manifest()
+        return self._parse_manifest(manifest_raw)
+
+    def _get_manifest(self) -> List[dict]:
+        """Loads the snap manifest file, returning the manifest for this architecture.
+
+        Raises:
+            SnapManifestError: when the manifest file cannot be loaded or parsed.
+
+        Returns:
+            A list of dicts describing snaps
+        """
+        if not self._manifest_path.exists():
+            raise SnapManifestError(f"Failed to find file={self._manifest_path}")
+        try:
+            with self._manifest_path.open() as f:
+                manifest = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            log.error("Failed to load manifest file=%s, %s", self._manifest_path, e)
+            raise SnapManifestError(f"Failed to load manifest file={self._manifest_path}")
+
+        manifest_this_arch = manifest.get(self.arch)
+        if not (isinstance(manifest, dict) and manifest_this_arch):
+            log.warning("Failed to find revision for arch=%s", self.arch)
+            raise SnapManifestError(f"Failed to find revision for arch={self.arch}")
+
+        return manifest_this_arch
+
+    def _parse_manifest(self, manifest: List[dict]) -> dict[str, SnapArgument]:
+        """Parses a manifest defined by a list of snap dicts, rendering them to SnapArguments."""
+        try:
+            manifest_parsed = {arg["name"]: parse_obj_as(SnapArgument, arg) for arg in manifest}
+        except (ValidationError, KeyError) as e:
+            log.warning("Failed to validate args=%s (%s)", self.arch, e)
+            raise SnapManifestError("Failed to validate snap args")
+
+        return manifest_parsed
+
+    def get_snap_arguments(self, name: str):
+        """Returns a SnapArgument for the given snap name."""
+        return self._manifest[name]
+
+
+def install_snap(snap_arguments: SnapArgument):
+    """Install the snap defined by a SnapArgument."""
+    cache = snap_lib.SnapCache()
+    snap = cache[snap_arguments.name]
+    if isinstance(snap_arguments, SnapFileArgument) and snap.revision != "x1":
+        snap_lib.install_local(**snap_arguments.dict(exclude_none=True))
+    elif isinstance(snap_arguments, SnapStoreArgument):
+        log.info(
+            "Ensuring %s snap is installed with channel=%s, revision=%s",
+            snap_arguments.name,
+            snap_arguments.channel,
+            snap_arguments.revision,
+        )
+        snap.ensure(**snap_arguments.dict(exclude_none=True))
+        # TODO: should hold be an argument in the yaml?
+        if snap_arguments.revision:
+            log.info(
+                "Setting snap refresh for %s to hold=forever because revision is defined",
+                snap_arguments.name,
+            )
+            snap.hold()

--- a/templates/snap_installation.yaml
+++ b/templates/snap_installation.yaml
@@ -8,3 +8,10 @@ amd64:
     # not required for the charm if revision is specified, but included so CI can look for new
     # versions in the channel
     channel: stable
+arm64:
+  - name: grafana-agent
+    install-type: store
+    revision: 23  # 0.39.2
+    # not required for the charm if revision is specified, but included so CI can look for new
+    # versions in the channel
+    channel: stable

--- a/templates/snap_installation.yaml
+++ b/templates/snap_installation.yaml
@@ -4,4 +4,7 @@
 amd64:
   - name: grafana-agent
     install-type: store
-    revision: 22
+    revision: 16  # 0.35.4
+    # not required for the charm if revision is specified, but included so CI can look for new
+    # versions in the channel
+    channel: stable

--- a/templates/snap_installation.yaml
+++ b/templates/snap_installation.yaml
@@ -1,0 +1,7 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+amd64:
+  - name: grafana-agent
+    install-type: store
+    revision: 22

--- a/tests/scenario/test_machine_charm/test_multiple_subordinates.py
+++ b/tests/scenario/test_machine_charm/test_multiple_subordinates.py
@@ -2,11 +2,26 @@
 # See LICENSE file for licensing details.
 
 import json
+from unittest.mock import PropertyMock, patch
 
 import charm
+import pytest
 from scenario import Context, PeerRelation, State, SubordinateRelation
 
 from tests.scenario.helpers import get_charm_meta
+
+
+@pytest.fixture(autouse=True)
+def mock_config_path(placeholder_cfg_path):
+    with patch("grafana_agent.CONFIG_PATH", placeholder_cfg_path):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_snap():
+    """Mock the charm's snap property so we don't access the host."""
+    with patch("charm.GrafanaAgentMachineCharm.snap", new_callable=PropertyMock):
+        yield
 
 
 def test_juju_info_and_cos_agent(vroot):

--- a/tests/scenario/test_setup_statuses.py
+++ b/tests/scenario/test_setup_statuses.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 import dataclasses
 from typing import Type
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import charm
 import grafana_agent
@@ -14,7 +14,7 @@ from scenario import Context, State
 from tests.scenario.helpers import get_charm_meta
 
 
-@pytest.fixture(params=["k8s", "lxd"])
+@pytest.fixture(params=["lxd"])
 def substrate(request):
     return request.param
 
@@ -46,7 +46,21 @@ def patch_all(substrate, mock_cfg_path):
         yield
 
 
-def test_install(charm_type, substrate, vroot):
+@pytest.fixture()
+def mock_snap():
+    """Mock the charm's snap property so we don't access the host."""
+    with patch(
+        "charm.GrafanaAgentMachineCharm.snap", new_callable=PropertyMock
+    ) as mocked_property:
+        mock_snap = mocked_property.return_value
+        # Mock the .present property of the snap object so the start event doesn't try to configure
+        # anything
+        mock_snap.present = False
+        yield
+
+
+@patch("charm.SnapManifest._get_system_arch", return_value="amd64")
+def test_install(_mock_manifest_get_system_arch, charm_type, substrate, vroot, mock_snap):
     context = Context(
         charm_type,
         meta=get_charm_meta(charm_type),
@@ -61,7 +75,7 @@ def test_install(charm_type, substrate, vroot):
         assert out.unit_status == ("unknown", "")
 
 
-def test_start(charm_type, substrate, vroot):
+def test_start(charm_type, substrate, vroot, mock_snap):
     context = Context(
         charm_type,
         meta=get_charm_meta(charm_type),

--- a/tests/unit/assets/snap_manifest.yaml
+++ b/tests/unit/assets/snap_manifest.yaml
@@ -1,0 +1,14 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+amd64:
+  - name: grafana-agent
+    install-type: store
+    revision: 22
+  - name: another-snap
+    install-type: store
+    channel: edge
+arm123:
+  - name: grafana-agent
+    install-type: store
+    revision: 123

--- a/tests/unit/test_relation_status.py
+++ b/tests/unit/test_relation_status.py
@@ -22,8 +22,12 @@ class TestRelationStatus(unittest.TestCase):
         self.config_path_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch("charm.snap")
+        patcher = patch("charm.snap_lib")
         self.mock_snap = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch.object(GrafanaAgentCharm, "_install")
+        self.mock_install = patcher.start()
         self.addCleanup(patcher.stop)
 
         self.harness = Harness(GrafanaAgentCharm)

--- a/tests/unit/test_snap_management.py
+++ b/tests/unit/test_snap_management.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import snap_management
+from snap_management import SnapManifest, SnapManifestError, SnapStoreArgument, install_snap
+
+snap_manifest_file = Path(__file__).parent / "assets/snap_manifest.yaml"
+
+snap_manifest_amd64 = [
+    {
+        "name": "grafana-agent",
+        "install-type": "store",
+        "revision": 22,
+    },
+    {
+        "name": "another-snap",
+        "install-type": "store",
+        "channel": "edge",
+    },
+]
+
+snap_manifest_arm123 = [
+    {
+        "name": "grafana-agent",
+        "install-type": "store",
+        "revision": 123,
+    }
+]
+
+snap_manifest_amd64_parsed = {
+    snap["name"]: SnapStoreArgument(**snap) for snap in snap_manifest_amd64
+}
+
+
+class TestSnapManifest:
+    """Tests for the SnapManifest class."""
+
+    @patch("snap_management.SnapManifest._get_parsed_manifest")
+    def test_get_arch_with_given_arch(self, _mocked_get_parsed_manifest):
+        expected_arch = "myarch"
+        sm = SnapManifest("./", expected_arch)
+
+        assert sm.arch == expected_arch
+
+    @patch("snap_management.SnapManifest._get_parsed_manifest")
+    def test_arch_detection(self, _mocked_get_parsed_manifest):
+        expected_arch = "amd64"
+        sm = SnapManifest("./", None)
+
+        assert sm.arch == expected_arch
+
+    @pytest.mark.parametrize(
+        "arch, expected_manifest",
+        [
+            ("amd64", snap_manifest_amd64),
+            ("arm123", snap_manifest_arm123),
+        ],
+    )
+    @patch("snap_management.SnapManifest._get_parsed_manifest")
+    def test_get_manifest(self, _mocked_get_parsed_manifest, arch, expected_manifest):
+        sm = SnapManifest(snap_manifest_file, arch)
+
+        manifest = sm._get_manifest()
+
+        assert manifest == expected_manifest
+
+    def test_get_manifest_file_does_not_exist(self):
+        with pytest.raises(SnapManifestError):
+            SnapManifest("non-existent-file", "amd64")
+
+    @patch("snap_management.SnapManifest._get_parsed_manifest")
+    def test_parse_manifest(self, _mocked_get_parsed_manifest):
+        sm = SnapManifest("./", "amd64")
+
+        actual_parsed = sm._parse_manifest(snap_manifest_amd64)
+
+        assert actual_parsed == snap_manifest_amd64_parsed
+
+    @patch("snap_management.SnapManifest._get_parsed_manifest")
+    def test_parse_manifest_invalid_format(self, _mocked_get_parsed_manifest):
+        sm = SnapManifest("./", "amd64")
+
+        with pytest.raises(SnapManifestError):
+            sm._parse_manifest([{}])
+
+    @patch("snap_management.SnapManifest._get_parsed_manifest")
+    def test_get_snap_argument(self, _mocked_get_parsed_manifest):
+        name = "another-snap"
+        expected_snap_args = snap_manifest_amd64_parsed[name]
+        sm = SnapManifest("./", "amd64")
+        sm._manifest = snap_manifest_amd64_parsed
+
+        actual_snap_args = sm.get_snap_arguments(name)
+
+        assert actual_snap_args == expected_snap_args
+
+    @patch("snap_management.SnapManifest._get_parsed_manifest")
+    def test_get_snap_argument_not_found(self, _mocked_get_parsed_manifest):
+        sm = SnapManifest("./", "amd64")
+        sm._manifest = {}
+
+        with pytest.raises(KeyError):
+            sm.get_snap_arguments("not-a-snap")
+
+
+class TestSnapInstall:
+
+    @patch("snap_management.snap_lib.SnapCache")
+    def test_install_store_snap_with_revision(self, mocked_cache):
+        name = "some-charm"
+        revision = 123
+        snap = mocked_cache()[name]
+        snap_arguments = SnapStoreArgument(name=name, revision=revision)
+        install_snap(snap_arguments)
+
+        snap.ensure.assert_called_once_with(
+            state=snap_management.snap_lib.SnapState.Present, revision=str(revision)
+        )
+        snap.hold.assert_called_once()

--- a/tests/unit/test_update_status.py
+++ b/tests/unit/test_update_status.py
@@ -21,8 +21,12 @@ class TestUpdateStatus(unittest.TestCase):
         self.config_path_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch("charm.snap")
+        patcher = patch("charm.snap_lib")
         self.mock_snap = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch.object(GrafanaAgentCharm, "_install")
+        self.mock_install = patcher.start()
         self.addCleanup(patcher.stop)
 
         self.harness = Harness(GrafanaAgentCharm)


### PR DESCRIPTION
## Issue
(see #131 for a different approach to this problem)

The current charm does not pin the snap installed, instead installing it from `latest/stable`.  This means that the snap version may float, potentially to a backwards incompatible version, without any intervention from the user.

The goals here are to:

* ensure the snap version installed is "held" (not upgraded on the fly during operation, without the admin asking for it). That way someone in the obs team pushing a new `latest/stable` cannot break existing deployments of the charm
* define what snap version any specific charm revision uses, making deployment predictable and reproducible (if someone deploys charm rev1 today and gets snap revA, they should get that same snap revA when they deploy again tomorrow, in a month, in a year, etc)

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR pins the snap to a specific revision by adding:
* a snap manifest file (snap_installation.yaml) which defines the snap(s) to be installed by this charm and their channels or revisions
* tooling to install the snaps in the manifest, including setting `snap refresh --hold=forever` for any snap that is pinned to a revision
* tests for above

The snap manifest file is intended to make future maintenance easier, enabling CI to create PRs for future version bumps.

The snap management tools are modified from [this](https://github.com/canonical/k8s-operator/blob/main/charms/worker/k8s/src/snap.py)

## Testing Instructions
CI coverage should handle testing.  If testing manually, you can `juju ssh` into the grafana-agent unit and check `snap info grafana-agent`, which should pin to revisionn 16 and say the snap has a "hold".

## Upgrade Notes
- 

## Todo:
* [ ] add the revision for the amd snap