### PR TITLE
Add physical disk removal alert

### DIFF
--- a/src/prometheus_alert_rules/disk.rules
+++ b/src/prometheus_alert_rules/disk.rules
@@ -73,3 +73,11 @@ groups:
         Host disk '{{ $labels.device }}' is probably writing too much data ({{ $value | printf "%.0f" }} > 50 MB/s) for last 5m.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
+  - alert: DiskRemoval
+    expr: count(node_disk_info{model!="", serial!="", wwn!=""}) by (instance, device) < on(instance, device) group_left() (count(node_disk_info{model!="", serial!="", wwn!=""} offset 30d) by (instance, device))
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Disk removal detected on {{ $labels.instance }}"
+      description: "Device {{ $labels.device }} on {{ $labels.instance }} has been removed which can be a hardware failure."


### PR DESCRIPTION
## Issue
In a case that a disk breaks and is not recognized anymore by the kernel, the metrics of a specific device will stop from been collected.


## Solution
Create a Prometheus alert rule to operators be able to notice that a physical disk was removed.


## Context
Virtual disks don't have the model, serial and wwn, so those fields are used to just target physical ones. If a physical disk is removed, the alert will continue to fire as long as the disk remains missing and up to 30 days from the removal.
