### PR TITLE
bump version of grafana-agent to 0.40.4 on all architectures

### DIFF
--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -24,8 +24,8 @@ log = logging.getLogger(__name__)
 _grafana_agent_snap_name = "grafana-agent"
 _grafana_agent_snaps = {
     # (confinement, arch): revision
-    ("strict", "amd64"): 16,
-    ("strict", "arm64"): 23,
+    ("strict", "amd64"): 51,  # 0.40.4
+    ("strict", "arm64"): 52,  # 0.40.4
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -45,7 +45,7 @@ deps =
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache --skip *.svg
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib}]


### PR DESCRIPTION
Bumps workload version of grafana-agent to 0.40.4 for both amd64 and arm64.  

Reasons:
* This change means that grafana-agent-operator and grafana-agent-k8s-operator support the same grafana-agent workload version.  Previous to this change, grafana-agent-operator's different architectures also used different workload versions (0.35.x for amd64, 0.39.x for arm64)
* https://github.com/canonical/grafana-agent-k8s-operator/issues/296 identified a possible issue with an older grafana-agent version

### Testing instructions
Should be covered by existing tests.  If workload deploys successfully it should be working as expected. 