### PR TITLE
feat(alerting): detect flapping alerts

### DIFF
--- a/src/prometheus_alert_rules/flapping.rules
+++ b/src/prometheus_alert_rules/flapping.rules
@@ -1,0 +1,14 @@
+groups:
+- name: AlertRules
+  rules:
+  - alert: AlertRulesFlapping
+    expr: changes(ALERTS_FOR_STATE{severity = "warning"}[1h]) > 5
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: Host '{{labels.instance}}' suffers from flapping alerts.
+      description: >-
+        Host '{{labels.instance}}' suffers from flapping warning-level alerts.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/host_health.rules
+++ b/src/prometheus_alert_rules/host_health.rules
@@ -1,0 +1,14 @@
+groups:
+- name: HostHealth
+  rules:
+  - alert: HostAvailable
+    expr: up < 1 or absent(up)
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: Host '{{labe;s.instance}}' is down.
+      description: >-
+        Host '{{ $labels.instance }}' is down.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We are currently not providing any alert rules that would detect when an alert is transitioning to and from `pending` in a fast pace, which means we could potentially loose out on information from recurring intermittent errors. 

## Solution
<!-- A summary of the solution addressing the above issue -->
Detect whenever an alert is transitioning more than 5 times in the last hour.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
resolves #145 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Deploy COS
2. Deploy a machine (juju deploy ubuntu)
3. Deploy Grafana Agent and relate it to ubuntu.
4. Relate the agent to COS
5. Verify that the alert rule has made it over
6. Turn off the host
7. Wait until a scrape has occurred
8. Turn on the host
9. Wait until a scrape has occurred
10. Repeat 6 to 9 5 times.
11. Wait 5 minutes
12. Verify that the alert is firing

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
