### PR TITLE
fix(alerting): Remove alert rules for detecting high disk read/write

### DIFF
--- a/src/prometheus_alert_rules/disk.rules
+++ b/src/prometheus_alert_rules/disk.rules
@@ -29,17 +29,6 @@ groups:
         Host filesystem '{{ $labels.mountpoint }}' is using {{ $value | printf "%.0f" }}% of the total space.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
-  - alert: HostReadonlyFilesystem
-    expr: node_filesystem_readonly{mountpoint!~"/snap/.*|/sys/fs/cgroup/.*"} > 0
-    for: 0m
-    labels:
-      severity: warning
-    annotations:
-      summary: Host filesystem '{{ $labels.mountpoint }}' is readonly (instance {{ $labels.instance }})
-      description: >-
-        Host filesystem '{{ $labels.mountpoint }}' is readonly.
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
   - alert: HostXFSError
     expr: node_filesystem_device_error{fstype="xfs"} > 0
     for: 0m

--- a/src/prometheus_alert_rules/disk.rules
+++ b/src/prometheus_alert_rules/disk.rules
@@ -51,25 +51,3 @@ groups:
          XFS error found for device '{{ $labels.device }}'.
            VALUE = {{ $value }}
            LABELS = {{ $labels }}
-  - alert: HostHighDiskReadRate
-    expr: irate(node_disk_read_bytes_total[2m]) / 1024 / 1024 > 50
-    for: 5m
-    labels:
-      severity: warning
-    annotations:
-      summary: Host high disk '{{ $labels.device }}' read rate (instance {{ $labels.instance }})
-      description: >-
-        Host disk '{{ $labels.device }}' is probably reading too much data ({{ $value | printf "%.0f" }} > 50 MB/s) for last 5m.
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
-  - alert: HostHighDiskWriteRate
-    expr: irate(node_disk_written_bytes_total[2m]) / 1024 / 1024 > 50
-    for: 5m
-    labels:
-      severity: warning
-    annotations:
-      summary: Host high disk '{{ $labels.device }}' write rate (instance {{ $labels.instance }})
-      description: >-
-        Host disk '{{ $labels.device }}' is probably writing too much data ({{ $value | printf "%.0f" }} > 50 MB/s) for last 5m.
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}


### PR DESCRIPTION
This check does not make a lot of sense as a canned alert rule as  it is way too context dependent. Resolves #42 

## Issue
<!-- What issue is this PR trying to solve? -->
The current disk IO alerts are set to too low of a threshold. 


## Solution
<!-- A summary of the solution addressing the above issue -->
Remove the alert rules

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
As suggested in #42, these alerts are far too context dependent to be part of the canned alert rules. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
