### PR TITLE
Make `cos_agent` charm library compatible with Pydantic v1/v2

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -213,13 +213,17 @@ from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Set, Tuple, Union
 
-import pydantic
 from cosl import GrafanaDashboard, JujuTopology
 from cosl.rules import AlertRules
 from ops.charm import RelationChangedEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
 from ops.model import Relation
 from ops.testing import CharmType
+
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 
 if TYPE_CHECKING:
     try:
@@ -234,9 +238,9 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 8
+LIBPATCH = 9
 
-PYDEPS = ["cosl", "pydantic < 2"]
+PYDEPS = ["cosl", "pydantic"]
 
 DEFAULT_RELATION_NAME = "cos-agent"
 DEFAULT_PEER_RELATION_NAME = "peers"


### PR DESCRIPTION
## Issue
Partially fixes https://github.com/canonical/grafana-agent-operator/issues/114, where the `cos_agent` charm library is not compatible with charms or other charm libraries that use Pydantic v2.

## Solution
Pydantic v2 provides full v1 compatibility via the `pydantic.v1` namespace. When it is detected that the environment is using Pydantic v2, switch to using that instead of importing Pydantic v2.

## Upgrade Notes
This should have no impact on any existing charms.