### PR TITLE
fix: remove `charm-strict-dependencies`

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -37,7 +37,6 @@ bases:
       architectures: ["amd64"]
 parts:
   charm:
-    charm-strict-dependencies: true
     build-packages:
     - git
 


### PR DESCRIPTION
## Issue
Fixes #158

Previously, we've incorrectly set `charm-strict-dependencies=True` without actually pinning our dependencies strictly.  This causes issues with Charmcraft 3.x, which actually enforces that we actuall pin these dependencies.

## Solution
Remove `charm-strict-dependencies`

## Context
#158

## Testing Instructions
If charm builds in charmcraft 3.x and deploys successfully (does not go to error), it worked.  See #158 for possible errors

## Upgrade Notes
