### PR TITLE
Fix pydantic models by dropping importing v1

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -228,17 +228,13 @@ from typing import (
     Union,
 )
 
+import pydantic
 from cosl import GrafanaDashboard, JujuTopology
 from cosl.rules import AlertRules
 from ops.charm import RelationChangedEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
 from ops.model import ModelError, Relation
 from ops.testing import CharmType
-
-try:
-    import pydantic.v1 as pydantic
-except ImportError:
-    import pydantic
 
 if TYPE_CHECKING:
     try:
@@ -253,7 +249,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = ["cosl", "pydantic"]
 
@@ -408,6 +404,7 @@ else:
             # Custom config key: whether to nest the whole datastructure (as json)
             # under a field or spread it out at the toplevel.
             _NEST_UNDER=None,  # type: ignore
+            arbitrary_types_allowed=True,
         )
         """Pydantic config."""
 


### PR DESCRIPTION
## Issue
After https://github.com/canonical/grafana-agent-operator/pull/156, changes in cos_agent done to support both pydantic versions fail with

```
  File "/home/ubuntu/grafana-agent-operator/lib/charms/grafana_agent/v0/cos_agent.py", line 333, in <module>
    if int(pydantic.version.VERSION.split(".")[0]) < 2:  # type: ignore
AttributeError: module 'pydantic.v1' has no attribute 'version'
```

## Solution
Remove conditional import of `pydantic.v1` and adjust the models instead to support both Pydantic versions.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
1. Run `tox -r` on the current code
2. To check how it behaves with pydantic v2, unpin pydantic in requirements.txt and run `tox -r` again. One scenario test will be failing as it creates a raw model, other than that everything should still work.


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
