### PR TITLE
fix: configure prometheus_remote_write config for non-leader

### DIFF
--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -57,7 +57,7 @@ class GrafanaCloudConfigRequirer(Object):
 
     def _on_relation_broken(self, event):
         self.on.cloud_config_revoked.emit()  # pyright: ignore
-    
+
     def _is_not_empty(self, s):
         return bool(s and not s.isspace())
 
@@ -124,7 +124,7 @@ class GrafanaCloudConfigRequirer(Object):
         """Return the prometheus endpoint dict."""
         if not self.prometheus_ready:
             return {}
-        
+
         endpoint = {}
         endpoint["url"] = self.prometheus_url
         if self.credentials:

--- a/tests/unit/test_cloud_integration.py
+++ b/tests/unit/test_cloud_integration.py
@@ -1,0 +1,72 @@
+import tempfile
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+import yaml
+from ops import BlockedStatus, ActiveStatus
+from ops.testing import Harness
+
+from charm import GrafanaAgentMachineCharm as GrafanaAgentCharm
+
+
+class TestUpdateStatus(unittest.TestCase):
+    def setUp(self, *unused):
+        patcher = patch.object(GrafanaAgentCharm, "_agent_version", property(lambda *_: "0.0.0"))
+        self.mock_version = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        temp_config_path = tempfile.mkdtemp() + "/grafana-agent.yaml"
+        # otherwise will attempt to write to /etc/grafana-agent.yaml
+        patcher = patch("grafana_agent.CONFIG_PATH", temp_config_path)
+        self.config_path_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch("charm.snap")
+        self.mock_snap = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch.object(GrafanaAgentCharm, "_install")
+        self.mock_install = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(self):
+        """Asserts that the prometheus remote write config is written correctly when the charm is a leader."""
+        harness = Harness(GrafanaAgentCharm)
+        harness.set_model_name(self.__class__.__name__)
+
+        harness.set_leader(True)
+        harness.begin_with_initial_hooks()
+
+        self._subtest_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(harness)
+
+    def test_prometheus_remote_write_config_with_grafana_cloud_integrator_on_non_leader(self):
+        """Asserts that the prometheus remote write config is written correctly when the charm is not a leader."""
+        harness = Harness(GrafanaAgentCharm)
+        harness.set_model_name(self.__class__.__name__)
+
+        harness.set_leader(False)
+        harness.begin_with_initial_hooks()
+
+        self._subtest_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(harness)
+
+    def _subtest_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(self, harness):
+        """Helper for all shared code between prometheus_remote_write_config tests."""
+        # WHEN an incoming relation is added
+        rel_id = harness.add_relation("juju-info", "grafana-agent")
+        harness.add_relation_unit(rel_id, "grafana-agent/0")
+
+        # THEN the charm goes into blocked status
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+
+        # AND WHEN all the necessary outgoing relations are added
+        # for outgoing in ["send-remote-write", "logging-consumer"]:
+        harness.add_relation("grafana-cloud-config", "grafana-cloud-integrator", app_data={"prometheus_url": "http://some.domain.name:9090/api/v1/write"})
+
+        # THEN the charm goes into active status
+        assert isinstance(harness.charm.unit.status, ActiveStatus)
+
+        # THEN with the expected prometheus endpoint settings are written to the config file
+        config = yaml.safe_load(Path(self.config_path_mock).read_text())
+        assert len(config["integrations"]["prometheus_remote_write"]) == 1
+        assert config["integrations"]["prometheus_remote_write"][0]["url"] == "http://some.domain.name:9090/api/v1/write"

--- a/tests/unit/test_cloud_integration.py
+++ b/tests/unit/test_cloud_integration.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 import yaml
-from charm import GrafanaAgentMachineCharm as GrafanaAgentCharm
 from ops import ActiveStatus, BlockedStatus
 from ops.testing import Harness
+
+from charm import GrafanaAgentMachineCharm as GrafanaAgentCharm
 
 
 class TestUpdateStatus(unittest.TestCase):

--- a/tests/unit/test_cloud_integration.py
+++ b/tests/unit/test_cloud_integration.py
@@ -1,13 +1,12 @@
 import tempfile
-from pathlib import Path
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 import yaml
-from ops import BlockedStatus, ActiveStatus
-from ops.testing import Harness
-
 from charm import GrafanaAgentMachineCharm as GrafanaAgentCharm
+from ops import ActiveStatus, BlockedStatus
+from ops.testing import Harness
 
 
 class TestUpdateStatus(unittest.TestCase):
@@ -38,7 +37,9 @@ class TestUpdateStatus(unittest.TestCase):
         harness.set_leader(True)
         harness.begin_with_initial_hooks()
 
-        self._subtest_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(harness)
+        self._subtest_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(
+            harness
+        )
 
     def test_prometheus_remote_write_config_with_grafana_cloud_integrator_on_non_leader(self):
         """Asserts that the prometheus remote write config is written correctly when the charm is not a leader."""
@@ -48,9 +49,13 @@ class TestUpdateStatus(unittest.TestCase):
         harness.set_leader(False)
         harness.begin_with_initial_hooks()
 
-        self._subtest_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(harness)
+        self._subtest_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(
+            harness
+        )
 
-    def _subtest_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(self, harness):
+    def _subtest_prometheus_remote_write_config_with_grafana_cloud_integrator_on_leader(
+        self, harness
+    ):
         """Helper for all shared code between prometheus_remote_write_config tests."""
         # WHEN an incoming relation is added
         rel_id = harness.add_relation("juju-info", "grafana-agent")
@@ -61,7 +66,11 @@ class TestUpdateStatus(unittest.TestCase):
 
         # AND WHEN all the necessary outgoing relations are added
         # for outgoing in ["send-remote-write", "logging-consumer"]:
-        harness.add_relation("grafana-cloud-config", "grafana-cloud-integrator", app_data={"prometheus_url": "http://some.domain.name:9090/api/v1/write"})
+        harness.add_relation(
+            "grafana-cloud-config",
+            "grafana-cloud-integrator",
+            app_data={"prometheus_url": "http://some.domain.name:9090/api/v1/write"},
+        )
 
         # THEN the charm goes into active status
         assert isinstance(harness.charm.unit.status, ActiveStatus)
@@ -69,4 +78,7 @@ class TestUpdateStatus(unittest.TestCase):
         # THEN with the expected prometheus endpoint settings are written to the config file
         config = yaml.safe_load(Path(self.config_path_mock).read_text())
         assert len(config["integrations"]["prometheus_remote_write"]) == 1
-        assert config["integrations"]["prometheus_remote_write"][0]["url"] == "http://some.domain.name:9090/api/v1/write"
+        assert (
+            config["integrations"]["prometheus_remote_write"][0]["url"]
+            == "http://some.domain.name:9090/api/v1/write"
+        )


### PR DESCRIPTION
## Issue
This PR fixes [this issue](https://github.com/canonical/grafana-cloud-integrator/issues/12) where grafana-agent is not correctly setting its prometheus_remote_write settings for non-leader units, leading to non-leader units not properly writing their data to prometheus

## Solution
The issue is caused by leadership guards in the grafana-cloud-integrator library's `GrafanaCloudConfigRequirer` relation handling.  Specifically, it does nothing on relation changed/relation broken events.  

The solution here is:
* add tests that demonstrate the prometheus_remote_write settings are written to config for both leader and non-leader units
* bump the grafana-cloud-integrator lib to fix the issue


## Context


## Testing Instructions

```bash
juju add-model ga1
juju deploy ubuntu -n 2
juju deploy grafana-agent --channel=latest/edge
juju deploy grafana-cloud-integrator --channel latest/edge --config prometheus-url=http://some.domain.name:9090/api/v1/write
juju relate grafana-agent ubuntu
juju relate grafana-agent:grafana-cloud-config grafana-cloud-integrator:grafana-cloud-config

# Then compare the following:
juju ssh grafana-agent/0 -- cat /etc/grafana-agent.yaml | yq .integrations.prometheus_remote_write
juju ssh grafana-agent/1 -- cat /etc/grafana-agent.yaml | yq .integrations.prometheus_remote_write
```

where we should see **both units** having the same data:
```yaml
- basic_auth:
    password: ''
    username: ''
  tls_config:
    insecure_skip_verify: false
  url: http://some.domain.name:9090/api/v1/write
```


## Upgrade Notes
