### PR TITLE
fix: sorting of imports to match ruff 0.6.x

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -17,9 +17,10 @@ from charms.operator_libs_linux.v2 import snap  # type: ignore
 from charms.tempo_k8s.v1.charm_tracing import trace_charm
 from cosl import JujuTopology
 from cosl.rules import AlertRules
-from grafana_agent import METRICS_RULES_SRC_PATH, GrafanaAgentCharm
 from ops.main import main
 from ops.model import BlockedStatus, MaintenanceStatus, Relation
+
+from grafana_agent import METRICS_RULES_SRC_PATH, GrafanaAgentCharm
 from snap_management import SnapSpecError, install_ga_snap
 
 logger = logging.getLogger(__name__)

--- a/tests/scenario/test_machine_charm/test_alert_labels.py
+++ b/tests/scenario/test_machine_charm/test_alert_labels.py
@@ -4,10 +4,10 @@
 import json
 from unittest.mock import PropertyMock, patch
 
-import charm
 import pytest
 from scenario import Context, PeerRelation, Relation, State, SubordinateRelation
 
+import charm
 from tests.scenario.helpers import get_charm_meta
 
 

--- a/tests/scenario/test_machine_charm/test_multiple_subordinates.py
+++ b/tests/scenario/test_machine_charm/test_multiple_subordinates.py
@@ -4,10 +4,10 @@
 import json
 from unittest.mock import PropertyMock, patch
 
-import charm
 import pytest
 from scenario import Context, PeerRelation, State, SubordinateRelation
 
+import charm
 from tests.scenario.helpers import get_charm_meta
 
 

--- a/tests/scenario/test_machine_charm/test_relation_priority.py
+++ b/tests/scenario/test_machine_charm/test_relation_priority.py
@@ -4,11 +4,11 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-import charm
 import pytest
 from cosl import GrafanaDashboard
 from scenario import Context, PeerRelation, State, SubordinateRelation
 
+import charm
 from tests.scenario.helpers import get_charm_meta
 from tests.scenario.test_machine_charm.helpers import set_run_out
 

--- a/tests/scenario/test_machine_charm/test_scrape_configs.py
+++ b/tests/scenario/test_machine_charm/test_scrape_configs.py
@@ -9,11 +9,12 @@ import uuid
 from pathlib import Path
 from unittest.mock import patch
 
-import charm
 import pytest
 import yaml
 from charms.grafana_agent.v0.cos_agent import CosAgentProviderUnitData
 from scenario import Context, Model, PeerRelation, Relation, State, SubordinateRelation
+
+import charm
 
 machine_meta = yaml.safe_load(
     (

--- a/tests/scenario/test_machine_charm/test_tracing_configuration.py
+++ b/tests/scenario/test_machine_charm/test_tracing_configuration.py
@@ -1,10 +1,11 @@
 from typing import get_args
 
 import pytest
-from charm import GrafanaAgentMachineCharm
 from charms.grafana_agent.v0.cos_agent import ReceiverProtocol
 from charms.tempo_k8s.v2.tracing import ReceiverProtocol as TracingReceiverProtocol
 from scenario import Context, State
+
+from charm import GrafanaAgentMachineCharm
 
 
 def test_cos_agent_receiver_protocols_match_with_tracing():

--- a/tests/scenario/test_setup_statuses.py
+++ b/tests/scenario/test_setup_statuses.py
@@ -4,13 +4,13 @@ import dataclasses
 from typing import Type
 from unittest.mock import PropertyMock, patch
 
-import charm
-import grafana_agent
 import pytest
 from ops import UnknownStatus, WaitingStatus
 from ops.testing import CharmType
 from scenario import Context, State
 
+import charm
+import grafana_agent
 from tests.scenario.helpers import get_charm_meta
 
 

--- a/tests/scenario/test_start_statuses.py
+++ b/tests/scenario/test_start_statuses.py
@@ -5,10 +5,11 @@ import inspect
 from pathlib import Path
 from unittest.mock import patch
 
-import charm
 import pytest
 import yaml
 from scenario import Context, State
+
+import charm
 
 CHARM_ROOT = Path(__file__).parent.parent.parent
 

--- a/tests/unit/test_fstab_parsing.py
+++ b/tests/unit/test_fstab_parsing.py
@@ -3,8 +3,9 @@
 import unittest
 from pathlib import Path
 
-from charm import SnapFstab
 from fs.tempfs import TempFS
+
+from charm import SnapFstab
 
 
 class TestFstabParsing(unittest.TestCase):

--- a/tests/unit/test_relation_status.py
+++ b/tests/unit/test_relation_status.py
@@ -5,9 +5,10 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from charm import GrafanaAgentMachineCharm as GrafanaAgentCharm
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
+
+from charm import GrafanaAgentMachineCharm as GrafanaAgentCharm
 
 
 class TestRelationStatus(unittest.TestCase):

--- a/tests/unit/test_update_status.py
+++ b/tests/unit/test_update_status.py
@@ -5,8 +5,9 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from charm import GrafanaAgentMachineCharm as GrafanaAgentCharm
 from ops.testing import Harness
+
+from charm import GrafanaAgentMachineCharm as GrafanaAgentCharm
 
 
 class TestUpdateStatus(unittest.TestCase):


### PR DESCRIPTION
## Issue
Not sure what has changed, but linting now fails within this repo after a ruff bump.  Fixing that here


## Solution
Running `tox -e fmt`

## Context


## Testing Instructions


## Upgrade Notes
