### PR TITLE
Classic snap

### DIFF
--- a/charmcraft-22.04.yaml
+++ b/charmcraft-22.04.yaml
@@ -119,6 +119,12 @@ peers:
 
 config:
   options:
+    classic_snap:
+      description: |
+        Choose whether to use the classic snap over the strictly confined
+        one. Defaults to "true".
+      type: boolean
+      default: true
     tls_insecure_skip_verify:
       description: |
         Flag to skip the verification for insecure TLS.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,18 @@ target-version = ["py38"]
 [tool.ruff]
 line-length = 99
 exclude = ["__pycache__", "*.egg_info"]
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
 # Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
 ignore = ["C901", "E501", "D107", "RET504"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 "tests/*" = ["D100","D101","D102","D103"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 # Static analysis tools configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,6 @@ branch = true
 [tool.coverage.report]
 show_missing = true
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py38"]
-
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
@@ -20,9 +15,8 @@ exclude = ["__pycache__", "*.egg_info"]
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
-# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["C901", "E501", "D107", "RET504"]
+ignore = ["C901", "D107", "E501", "RET504"]
 
 [tool.ruff.lint.per-file-ignores]
 # D100, D101, D102, D103: Ignore missing docstrings in tests

--- a/src/charm.py
+++ b/src/charm.py
@@ -238,7 +238,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         try:
             # install_ga_snap calls snap.ensure so it should do the right thing whether the track
             # changes or not.
-            install_ga_snap(classic=self.config["classic_snap"])  # type: ignore
+            install_ga_snap(classic=bool(self.config["classic_snap"]))
         except (snap.SnapError, SnapSpecError) as e:
             raise GrafanaAgentInstallError("Failed to refresh grafana-agent.") from e
 
@@ -250,7 +250,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         """Install/refresh the Grafana Agent snap."""
         self.unit.status = MaintenanceStatus("Installing grafana-agent snap")
         try:
-            install_ga_snap(classic=self.config["classic_snap"])  # type: ignore
+            install_ga_snap(classic=bool(self.config["classic_snap"]))
         except (snap.SnapError, SnapSpecError) as e:
             raise GrafanaAgentInstallError("Failed to install grafana-agent.") from e
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -256,9 +256,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         self.unit.status = MaintenanceStatus("Starting grafana-agent snap")
 
         try:
-            # self.snap.start(enable=True)
-            subprocess.run(["snap", "enable", "grafana-agent"])
-            subprocess.run(["snap", "start", "grafana-agent"])
+            self.snap.start(enable=True)
         except snap.SnapError as e:
             raise GrafanaAgentServiceError("Failed to start grafana-agent") from e
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -526,7 +526,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         ] + topology_relabels  # type: ignore
 
     def _evaluate_log_paths(self, paths: List[str], snap: str, app: str) -> List[str]:
-        """Evaluate each log path in order to deal with environment variables."""
+        """Evaluate each log path using snap to resolve environment variables."""
         # There is a potential for shell injection here. It seems okay because the potential
         # attacking charm has root access on the machine already anyway.
         new_paths = []

--- a/src/charm.py
+++ b/src/charm.py
@@ -622,7 +622,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                         endpoint.owner,
                         f"{path}/**",
                         topology.application,
-                        topology.unit,
+                        str(topology.unit),
                         self._path_label(path),
                     )
                     shared_logs_configs.append(job)

--- a/src/charm.py
+++ b/src/charm.py
@@ -584,7 +584,11 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         return job
 
     def _path_label(self, path):
-        """Best effort at figuring out what the path label should be."""
+        """Best effort at figuring out what the path label should be.
+
+        Try to make the path reflect what it would normally be with a non snap version of the
+        software.
+        """
         match = re.match("^.*(var/log/.*$)", path)
         if match:
             return match.group(1)

--- a/src/charm.py
+++ b/src/charm.py
@@ -525,7 +525,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
             }
         ] + topology_relabels  # type: ignore
 
-    def _evaluate_log_paths(self, paths, snap, app):
+    def _evaluate_log_paths(self, paths: List[str], snap: str, app: str) -> List[str]:
         """Evaluate each log path in order to deal with environment variables."""
         # There is a potential for shell injection here. It seems okay because the potential
         # attacking charm has root access on the machine already anyway.
@@ -540,7 +540,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
             new_paths.append(p.stdout.strip())
         return new_paths
 
-    def _snap_plug_job(self, owner, target_path, app, unit, label_path):
+    def _snap_plug_job(self, owner: str, target_path: str, app: str, unit: str, label_path: str) -> dict:
         job_name = f"{owner}-{label_path.replace('/', '-')}"
         job = {
             "job_name": job_name,

--- a/src/charm.py
+++ b/src/charm.py
@@ -415,7 +415,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         )
         return {
             "node_exporter": {
-                "rootfs_path": "/var/lib/snapd/hostfs" if bool(self.config["classic_snap"]) else "/",
+                "rootfs_path": "/" if bool(self.config["classic_snap"]) else "/var/lib/snapd/hostfs",
                 "enabled": True,
                 "enable_collectors": [
                     "logind",

--- a/src/charm.py
+++ b/src/charm.py
@@ -196,7 +196,6 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         self.framework.observe(self.on.start, self._on_start)
         self.framework.observe(self.on.stop, self._on_stop)
         self.framework.observe(self.on.remove, self._on_remove)
-        self.framework.observe(self.on.config_changed, self.on_config_changed)
 
     @property
     def snap(self):
@@ -230,10 +229,6 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
 
         self._update_status()
 
-    def on_config_changed(self, _event) -> None:
-        """Handler for the config changed event."""
-        self._verify_snap_track()
-
     def _verify_snap_track(self) -> None:
         try:
             # install_ga_snap calls snap.ensure so it should do the right thing whether the track
@@ -261,7 +256,9 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         self.unit.status = MaintenanceStatus("Starting grafana-agent snap")
 
         try:
-            self.snap.start(enable=True)
+             # self.snap.start(enable=True)
+             subprocess.run(["snap", "enable", "grafana-agent"])
+             subprocess.run(["snap", "start", "grafana-agent"])
         except snap.SnapError as e:
             raise GrafanaAgentServiceError("Failed to start grafana-agent") from e
 
@@ -418,7 +415,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         )
         return {
             "node_exporter": {
-                "rootfs_path": "/var/lib/snapd/hostfs",
+                "rootfs_path": "/var/lib/snapd/hostfs" if bool(self.config["classic_snap"]) else "/",
                 "enabled": True,
                 "enable_collectors": [
                     "logind",

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,6 +4,7 @@
 # See LICENSE file for licensing details.
 
 """A  juju charm for Grafana Agent on Kubernetes."""
+
 import logging
 import os
 import re
@@ -187,7 +188,8 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
             self._on_cos_data_changed,
         )
         self.framework.observe(
-            self._cos.on.validation_error, self._on_cos_validation_error  # pyright: ignore
+            self._cos.on.validation_error,
+            self._on_cos_validation_error,  # pyright: ignore
         )
         self.framework.observe(self.on["juju_info"].relation_joined, self._on_juju_info_joined)
         self.framework.observe(self.on.install, self.on_install)

--- a/src/charm.py
+++ b/src/charm.py
@@ -605,8 +605,8 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         shared_logs_configs = []
 
         if self.config["classic_snap"]:
+            # Iterate through each logging endpoint.
             for endpoint, topology in self._cos.snap_log_endpoints_with_topology:
-                # endpoint: owner:name
                 try:
                     with open(f"/snap/{endpoint.owner}/current/meta/snap.yaml") as f:
                         snap_yaml = yaml.safe_load(f)
@@ -615,13 +615,16 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                         f"snap file for {endpoint.owner} not found. It is likely not installed. Skipping."
                     )
                     continue
+                # Get the directories we need to monitor.
                 log_dirs = snap_yaml["slots"][endpoint.name]["source"]["read"]
                 for key in snap_yaml["apps"].keys():
                     snap_app_name = key  # Just use any app.
                     break
+                # Evaluate any variables in the paths.
                 log_dirs = self._evaluate_log_paths(
                     paths=log_dirs, snap=endpoint.owner, app=snap_app_name
                 )
+                # Create a job for each path.
                 for path in log_dirs:
                     job = self._snap_plug_job(
                         endpoint.owner,

--- a/src/charm.py
+++ b/src/charm.py
@@ -540,7 +540,9 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
             new_paths.append(p.stdout.strip())
         return new_paths
 
-    def _snap_plug_job(self, owner: str, target_path: str, app: str, unit: str, label_path: str) -> dict:
+    def _snap_plug_job(
+        self, owner: str, target_path: str, app: str, unit: str, label_path: str
+    ) -> dict:
         job_name = f"{owner}-{label_path.replace('/', '-')}"
         job = {
             "job_name": job_name,

--- a/src/charm.py
+++ b/src/charm.py
@@ -526,7 +526,11 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         ] + topology_relabels  # type: ignore
 
     def _evaluate_log_paths(self, paths: List[str], snap: str, app: str) -> List[str]:
-        """Evaluate each log path using snap to resolve environment variables."""
+        """Evaluate each log path using snap to resolve environment variables.
+
+        Raises:
+            Exception: If echo fails.
+        """
         # There is a potential for shell injection here. It seems okay because the potential
         # attacking charm has root access on the machine already anyway.
         new_paths = []

--- a/src/charm.py
+++ b/src/charm.py
@@ -256,9 +256,9 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         self.unit.status = MaintenanceStatus("Starting grafana-agent snap")
 
         try:
-             # self.snap.start(enable=True)
-             subprocess.run(["snap", "enable", "grafana-agent"])
-             subprocess.run(["snap", "start", "grafana-agent"])
+            # self.snap.start(enable=True)
+            subprocess.run(["snap", "enable", "grafana-agent"])
+            subprocess.run(["snap", "start", "grafana-agent"])
         except snap.SnapError as e:
             raise GrafanaAgentServiceError("Failed to start grafana-agent") from e
 
@@ -415,7 +415,9 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         )
         return {
             "node_exporter": {
-                "rootfs_path": "/" if bool(self.config["classic_snap"]) else "/var/lib/snapd/hostfs",
+                "rootfs_path": "/"
+                if bool(self.config["classic_snap"])
+                else "/var/lib/snapd/hostfs",
                 "enabled": True,
                 "enable_collectors": [
                     "logind",

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -609,9 +609,7 @@ class GrafanaAgentCharm(CharmBase):
     def _on_dashboard_status_changed(self, _event=None):
         """Re-initialize dashboards to forward."""
         # TODO: add constructor arg for `inject_dropdowns=False` instead of 'private' method?
-        self._grafana_dashboards_provider._reinitialize_dashboard_data(
-            inject_dropdowns=False
-        )  # noqa
+        self._grafana_dashboards_provider._reinitialize_dashboard_data(inject_dropdowns=False)  # noqa
         self._update_status()
 
     def _enhance_endpoints_with_tls(self, endpoints) -> List[Dict[str, Any]]:
@@ -923,12 +921,12 @@ class GrafanaAgentCharm(CharmBase):
             for config in configs:
                 for scrape_config in config.get("scrape_configs", []):
                     if scrape_config.get("loki_push_api"):
-                        scrape_config["loki_push_api"]["server"][
-                            "http_tls_config"
-                        ] = self.tls_config
-                        scrape_config["loki_push_api"]["server"][
-                            "grpc_tls_config"
-                        ] = self.tls_config
+                        scrape_config["loki_push_api"]["server"]["http_tls_config"] = (
+                            self.tls_config
+                        )
+                        scrape_config["loki_push_api"]["server"]["grpc_tls_config"] = (
+                            self.tls_config
+                        )
 
         configs.extend(self._additional_log_configs)  # type: ignore
         return (

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -271,6 +271,7 @@ class GrafanaAgentCharm(CharmBase):
 
     def _on_config_changed(self, _event=None):
         """Rebuild the config."""
+        self._verify_snap_track()
         self._update_config()
         self._update_status()
 
@@ -297,6 +298,9 @@ class GrafanaAgentCharm(CharmBase):
         self.run(["update-ca-certificates", "--fresh"])
 
     # Abstract Methods
+    def _verify_snap_track(self) -> None:
+        raise NotImplementedError("Please override the _verify_snap_track method")
+
     @property
     def is_k8s(self) -> bool:
         """Is this a k8s charm."""

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Common logic for both k8s and machine charms for Grafana Agent."""
+
 import json
 import logging
 import os

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -13,6 +13,7 @@ Modified from https://github.com/canonical/k8s-operator/blob/main/charms/worker/
 
 import logging
 import platform
+import subprocess
 
 import charms.operator_libs_linux.v2.snap as snap_lib
 
@@ -26,8 +27,8 @@ _grafana_agent_snaps = {
     # (confinement, arch): revision
     ("strict", "amd64"): 51,  # 0.40.4
     ("strict", "arm64"): 52,  # 0.40.4
-    ("classic", "amd64"): 59,  # 0.40.4
-    ("classic", "arm64"): 60,  # 0.40.4
+    ("classic", "amd64"): 82,  # 0.40.4
+    ("classic", "arm64"): 83,  # 0.40.4
 }
 
 
@@ -65,7 +66,18 @@ def _install_snap(
         f"Ensuring {name} snap is installed at revision={revision}"
         f" with classic confinement={classic}"
     )
-    snap.ensure(state=snap_lib.SnapState.Present, revision=revision, classic=classic)
+    # snap.ensure(state=snap_lib.SnapState.Present, revision=revision, classic=classic)
+    # Currently, snap.ensure does not properly use the classic flag. Use the commented line above
+    # instead of the below code once the issue is resolved.
+    # https://github.com/canonical/operator-libs-linux/issues/129
+    if snap.present:
+        cmd = ["snap", "refresh", "grafana-agent", f'--revision="{revision}"']
+        if classic:
+            cmd.append("--classic")
+        subprocess.run(cmd)
+    else:
+        snap.ensure(state=snap_lib.SnapState.Present, revision=revision, classic=classic)
+
     snap.hold()
 
 

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -26,6 +26,8 @@ _grafana_agent_snaps = {
     # (confinement, arch): revision
     ("strict", "amd64"): 51,  # 0.40.4
     ("strict", "arm64"): 52,  # 0.40.4
+    ("classic", "amd64"): 59,  # 0.40.4
+    ("classic", "arm64"): 60,  # 0.40.4
 }
 
 

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -70,7 +70,7 @@ def _install_snap(
     # instead of the below code once the issue is resolved.
     # https://github.com/canonical/operator-libs-linux/issues/129
     if snap.present:
-        if snap.revision() != revision:
+        if snap.revision != revision:
             cmd = ["snap", "refresh", "grafana-agent", f'--revision="{revision}"']
             if classic:
                 cmd.append("--classic")

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -70,10 +70,12 @@ def _install_snap(
     # instead of the below code once the issue is resolved.
     # https://github.com/canonical/operator-libs-linux/issues/129
     if snap.present:
-        cmd = ["snap", "refresh", "grafana-agent", f'--revision="{revision}"']
-        if classic:
-            cmd.append("--classic")
-        subprocess.run(cmd)
+        if snap.revision() != revision:
+            cmd = ["snap", "refresh", "grafana-agent", f'--revision="{revision}"']
+            if classic:
+                cmd.append("--classic")
+            subprocess.run(cmd)
+            snap.start(enable=True)
     else:
         snap.ensure(state=snap_lib.SnapState.Present, revision=revision, classic=classic)
 

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -10,7 +10,6 @@
 Modified from https://github.com/canonical/k8s-operator/blob/main/charms/worker/k8s/src/snap.py
 """
 
-
 import logging
 import platform
 import subprocess

--- a/tests/integration/test_classic_config_flag.py
+++ b/tests/integration/test_classic_config_flag.py
@@ -74,9 +74,9 @@ async def test_switch_to_strict(ops_test: OpsTest):
     # $ juju ssh agent/0 snap services grafana-agent
     # Service                      Startup  Current  Notes
     # grafana-agent.grafana-agent  enabled  active   -
-    ops_test.model.applications[agent.name].set_config({"classic_snap": False})
+    await ops_test.model.applications[agent.name].set_config({"classic_snap": "false"})
     await ops_test.model.wait_for_idle(
-        apps=[principal.name, agent.name], status="active", idle_period=300
+        apps=[principal.name, agent.name], status="active"
     )
     out = await ssh(ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement")
     assert out.split()[1] == "strict"
@@ -90,9 +90,9 @@ async def test_switch_to_classic(ops_test: OpsTest):
     # $ juju ssh agent/0 snap services grafana-agent
     # Service                      Startup  Current  Notes
     # grafana-agent.grafana-agent  enabled  active   -
-    ops_test.model.applications[agent.name].set_config({"classic_snap": True})
+    await ops_test.model.applications[agent.name].set_config({"classic_snap": "true"})
     await ops_test.model.wait_for_idle(
-        apps=[principal.name, agent.name], status="active", idle_period=300
+        apps=[principal.name, agent.name], status="active"
     )
     out = await ssh(ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement")
     assert out.split()[1] == "classic"

--- a/tests/integration/test_classic_config_flag.py
+++ b/tests/integration/test_classic_config_flag.py
@@ -76,7 +76,7 @@ async def test_switch_to_strict(ops_test: OpsTest):
     # grafana-agent.grafana-agent  enabled  active   -
     ops_test.model.applications[agent.name].set_config({"classic_snap": False})
     await ops_test.model.wait_for_idle(
-        apps=[principal.name, agent.name], status="active", idle_period=15
+        apps=[principal.name, agent.name], status="active", idle_period=300
     )
     out = await ssh(ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement")
     assert out.split()[1] == "strict"
@@ -92,7 +92,7 @@ async def test_switch_to_classic(ops_test: OpsTest):
     # grafana-agent.grafana-agent  enabled  active   -
     ops_test.model.applications[agent.name].set_config({"classic_snap": True})
     await ops_test.model.wait_for_idle(
-        apps=[principal.name, agent.name], status="active", idle_period=15
+        apps=[principal.name, agent.name], status="active", idle_period=300
     )
     out = await ssh(ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement")
     assert out.split()[1] == "classic"

--- a/tests/integration/test_classic_config_flag.py
+++ b/tests/integration/test_classic_config_flag.py
@@ -1,0 +1,104 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import json
+import logging
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+from juju.errors import JujuError
+from pytest_operator.plugin import OpsTest
+
+agent = SimpleNamespace(name="agent")
+principal = SimpleNamespace(charm="ubuntu", name="principal")
+
+logger = logging.getLogger(__name__)
+
+
+async def ssh(ops_test, app_name: str, command: str) -> List[str]:
+    """Run a command in all units of the given apps and return all the outputs."""
+    unit = ops_test.model.applications[app_name].units[0]
+    try:
+        return await unit.ssh(command)
+    except JujuError as e:
+        pytest.fail(f"Failed to run ssh command '{command}' in {app_name}: {e.message}")
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, grafana_agent_charm):
+    # Principal
+    await ops_test.model.deploy(
+        principal.charm, application_name=principal.name, series="jammy"
+    )
+
+    # Workaround: `charmcraft pack` produces two files, but `ops_test.build_charm` returns the
+    # first one. Since primary is jammy, we know we need to deploy the jammy grafana agent charm,
+    # otherwise we'd get an error such as:
+    #   ImportError: libssl.so.1.1: cannot open shared object file: No such file or directory
+    jammy_charm_path = grafana_agent_charm.parent / "grafana-agent_ubuntu-22.04-amd64.charm"
+
+    # Subordinate
+    await ops_test.model.deploy(
+        jammy_charm_path, application_name=agent.name, num_units=0, series="jammy"
+    )
+
+    # Placeholder for o11y relations (otherwise grafana agent charm is in blocked status)
+    await ops_test.model.deploy(
+        "grafana-cloud-integrator",
+        application_name="gci",
+        num_units=1,
+        series="focal",
+        channel="edge",
+    )
+
+    await ops_test.model.add_relation("agent:juju-info", principal.name)
+    await ops_test.model.add_relation("agent:grafana-cloud-config", "gci")
+    await ops_test.model.wait_for_idle(apps=[principal.name, agent.name], status="active")
+
+
+@pytest.mark.abort_on_fail
+async def test_classic_by_default(ops_test: OpsTest):
+    # WHEN the charm is related to a principal over `juju-info`
+
+    # THEN all units of the principal have the charm in 'enabled/active' state
+    # $ juju ssh agent/0 snap services grafana-agent
+    # Service                      Startup  Current  Notes
+    # grafana-agent.grafana-agent  enabled  active   -
+    out = await ssh(
+        ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement"
+    )
+    assert out.split()[1] == "classic"
+
+
+@pytest.mark.abort_on_fail
+async def test_switch_to_strict(ops_test: OpsTest):
+    # WHEN the charm is related to a principal over `juju-info`
+
+    # THEN all units of the principal have the charm in 'enabled/active' state
+    # $ juju ssh agent/0 snap services grafana-agent
+    # Service                      Startup  Current  Notes
+    # grafana-agent.grafana-agent  enabled  active   -
+    ops_test.model.applications[agent.name].set_config({"classic_snap": False})
+    await ops_test.model.wait_for_idle(apps=[principal.name, agent.name], status="active", idle_period=15)
+    out = await ssh(
+        ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement"
+    )
+    assert out.split()[1] == "strict"
+
+
+@pytest.mark.abort_on_fail
+async def test_switch_to_classic(ops_test: OpsTest):
+    # WHEN the charm is related to a principal over `juju-info`
+
+    # THEN all units of the principal have the charm in 'enabled/active' state
+    # $ juju ssh agent/0 snap services grafana-agent
+    # Service                      Startup  Current  Notes
+    # grafana-agent.grafana-agent  enabled  active   -
+    ops_test.model.applications[agent.name].set_config({"classic_snap": True})
+    await ops_test.model.wait_for_idle(apps=[principal.name, agent.name], status="active", idle_period=15)
+    out = await ssh(
+        ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement"
+    )
+    assert out.split()[1] == "classic"

--- a/tests/integration/test_classic_config_flag.py
+++ b/tests/integration/test_classic_config_flag.py
@@ -1,8 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import asyncio
-import json
 import logging
 from types import SimpleNamespace
 from typing import List
@@ -29,9 +27,7 @@ async def ssh(ops_test, app_name: str, command: str) -> List[str]:
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, grafana_agent_charm):
     # Principal
-    await ops_test.model.deploy(
-        principal.charm, application_name=principal.name, series="jammy"
-    )
+    await ops_test.model.deploy(principal.charm, application_name=principal.name, series="jammy")
 
     # Workaround: `charmcraft pack` produces two files, but `ops_test.build_charm` returns the
     # first one. Since primary is jammy, we know we need to deploy the jammy grafana agent charm,
@@ -66,9 +62,7 @@ async def test_classic_by_default(ops_test: OpsTest):
     # $ juju ssh agent/0 snap services grafana-agent
     # Service                      Startup  Current  Notes
     # grafana-agent.grafana-agent  enabled  active   -
-    out = await ssh(
-        ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement"
-    )
+    out = await ssh(ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement")
     assert out.split()[1] == "classic"
 
 
@@ -81,10 +75,10 @@ async def test_switch_to_strict(ops_test: OpsTest):
     # Service                      Startup  Current  Notes
     # grafana-agent.grafana-agent  enabled  active   -
     ops_test.model.applications[agent.name].set_config({"classic_snap": False})
-    await ops_test.model.wait_for_idle(apps=[principal.name, agent.name], status="active", idle_period=15)
-    out = await ssh(
-        ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement"
+    await ops_test.model.wait_for_idle(
+        apps=[principal.name, agent.name], status="active", idle_period=15
     )
+    out = await ssh(ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement")
     assert out.split()[1] == "strict"
 
 
@@ -97,8 +91,8 @@ async def test_switch_to_classic(ops_test: OpsTest):
     # Service                      Startup  Current  Notes
     # grafana-agent.grafana-agent  enabled  active   -
     ops_test.model.applications[agent.name].set_config({"classic_snap": True})
-    await ops_test.model.wait_for_idle(apps=[principal.name, agent.name], status="active", idle_period=15)
-    out = await ssh(
-        ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement"
+    await ops_test.model.wait_for_idle(
+        apps=[principal.name, agent.name], status="active", idle_period=15
     )
+    out = await ssh(ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement")
     assert out.split()[1] == "classic"

--- a/tests/integration/test_classic_config_flag.py
+++ b/tests/integration/test_classic_config_flag.py
@@ -75,9 +75,7 @@ async def test_switch_to_strict(ops_test: OpsTest):
     # Service                      Startup  Current  Notes
     # grafana-agent.grafana-agent  enabled  active   -
     await ops_test.model.applications[agent.name].set_config({"classic_snap": "false"})
-    await ops_test.model.wait_for_idle(
-        apps=[principal.name, agent.name], status="active"
-    )
+    await ops_test.model.wait_for_idle(apps=[principal.name, agent.name], status="active")
     out = await ssh(ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement")
     assert out.split()[1] == "strict"
 
@@ -91,8 +89,6 @@ async def test_switch_to_classic(ops_test: OpsTest):
     # Service                      Startup  Current  Notes
     # grafana-agent.grafana-agent  enabled  active   -
     await ops_test.model.applications[agent.name].set_config({"classic_snap": "true"})
-    await ops_test.model.wait_for_idle(
-        apps=[principal.name, agent.name], status="active"
-    )
+    await ops_test.model.wait_for_idle(apps=[principal.name, agent.name], status="active")
     out = await ssh(ops_test, agent.name, "snap info --verbose grafana-agent | grep confinement")
     assert out.split()[1] == "classic"

--- a/tests/integration/test_classic_config_flag.py
+++ b/tests/integration/test_classic_config_flag.py
@@ -49,8 +49,8 @@ async def test_build_and_deploy(ops_test: OpsTest, grafana_agent_charm):
         channel="edge",
     )
 
-    await ops_test.model.add_relation("agent:juju-info", principal.name)
-    await ops_test.model.add_relation("agent:grafana-cloud-config", "gci")
+    await ops_test.model.integrate("agent:juju-info", principal.name)
+    await ops_test.model.integrate("agent:grafana-cloud-config", "gci")
     await ops_test.model.wait_for_idle(apps=[principal.name, agent.name], status="active")
 
 

--- a/tests/integration/test_juju_info_cos_agent.py
+++ b/tests/integration/test_juju_info_cos_agent.py
@@ -80,10 +80,10 @@ async def test_build_and_deploy(ops_test: OpsTest, grafana_agent_charm):
 @pytest.mark.abort_on_fail
 async def test_service(ops_test: OpsTest):
     # WHEN the charm is related to a principal over `juju-info`
-    await ops_test.model.add_relation("agent:juju-info", principal.name)
-    await ops_test.model.add_relation("hwo:general-info", principal.name)
-    await ops_test.model.add_relation("hwo:cos-agent", "agent:cos-agent")
-    await ops_test.model.add_relation("agent:grafana-cloud-config", "gci")
+    await ops_test.model.integrate("agent:juju-info", principal.name)
+    await ops_test.model.integrate("hwo:general-info", principal.name)
+    await ops_test.model.integrate("hwo:cos-agent", "agent:cos-agent")
+    await ops_test.model.integrate("agent:grafana-cloud-config", "gci")
     await ops_test.model.wait_for_idle(apps=[principal.name, agent.name], status="active")
 
     # THEN all units of the principal have the charm in 'enabled/active' state

--- a/tests/scenario/test_machine_charm/conftest.py
+++ b/tests/scenario/test_machine_charm/conftest.py
@@ -28,3 +28,14 @@ def mock_refresh():
     """Mock the refresh call so we don't access the host."""
     with patch("snap_management._install_snap", new_callable=PropertyMock):
         yield
+
+
+CONFIG_MATRIX = [
+    {"classic_snap": True},
+    {"classic_snap": False},
+]
+
+
+@pytest.fixture(params=CONFIG_MATRIX)
+def charm_config(request):
+    return request.param

--- a/tests/scenario/test_machine_charm/conftest.py
+++ b/tests/scenario/test_machine_charm/conftest.py
@@ -1,6 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 
@@ -13,4 +13,18 @@ def placeholder_cfg_path(tmp_path):
 @pytest.fixture()
 def mock_config_path(placeholder_cfg_path):
     with patch("grafana_agent.CONFIG_PATH", placeholder_cfg_path):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_snap():
+    """Mock the charm's snap property so we don't access the host."""
+    with patch("charm.GrafanaAgentMachineCharm.snap", new_callable=PropertyMock):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_refresh():
+    """Mock the refresh call so we don't access the host."""
+    with patch("snap_management._install_snap", new_callable=PropertyMock):
         yield

--- a/tests/scenario/test_machine_charm/test_alert_labels.py
+++ b/tests/scenario/test_machine_charm/test_alert_labels.py
@@ -15,7 +15,7 @@ def use_mock_config_path(mock_config_path):
     yield
 
 
-def test_metrics_alert_rule_labels(vroot):
+def test_metrics_alert_rule_labels(vroot, charm_config):
     """Check that metrics alert rules are labeled with principal topology."""
     cos_agent_primary_data = {
         "config": json.dumps(
@@ -109,6 +109,7 @@ def test_metrics_alert_rule_labels(vroot):
             remote_write_relation,
             PeerRelation("peers"),
         ],
+        config=charm_config,
     )
 
     state_0 = context.run(event=cos_agent_primary_relation.changed_event, state=state)

--- a/tests/scenario/test_machine_charm/test_alert_labels.py
+++ b/tests/scenario/test_machine_charm/test_alert_labels.py
@@ -2,26 +2,17 @@
 # See LICENSE file for licensing details.
 
 import json
-from unittest.mock import PropertyMock, patch
 
 import pytest
 from scenario import Context, PeerRelation, Relation, State, SubordinateRelation
 
 import charm
-from tests.scenario.helpers import get_charm_meta
 
 
 @pytest.fixture(autouse=True)
 def use_mock_config_path(mock_config_path):
     # Use the common mock_config_path fixture from conftest.py
     yield
-
-
-@pytest.fixture(autouse=True)
-def mock_snap():
-    """Mock the charm's snap property so we don't access the host."""
-    with patch("charm.GrafanaAgentMachineCharm.snap", new_callable=PropertyMock):
-        yield
 
 
 def test_metrics_alert_rule_labels(vroot):
@@ -108,7 +99,6 @@ def test_metrics_alert_rule_labels(vroot):
 
     context = Context(
         charm_type=charm.GrafanaAgentMachineCharm,
-        meta=get_charm_meta(charm.GrafanaAgentMachineCharm),
         charm_root=vroot,
     )
     state = State(
@@ -122,9 +112,7 @@ def test_metrics_alert_rule_labels(vroot):
     )
 
     state_0 = context.run(event=cos_agent_primary_relation.changed_event, state=state)
-    (vroot / "charmcraft.yaml").unlink(missing_ok=True)
     state_1 = context.run(event=cos_agent_subordinate_relation.changed_event, state=state_0)
-    (vroot / "charmcraft.yaml").unlink(missing_ok=True)
     state_2 = context.run(event=remote_write_relation.joined_event, state=state_1)
 
     alert_rules = json.loads(state_2.relations[2].local_app_data["alert_rules"])

--- a/tests/scenario/test_machine_charm/test_multiple_subordinates.py
+++ b/tests/scenario/test_machine_charm/test_multiple_subordinates.py
@@ -2,26 +2,17 @@
 # See LICENSE file for licensing details.
 
 import json
-from unittest.mock import PropertyMock, patch
 
 import pytest
 from scenario import Context, PeerRelation, State, SubordinateRelation
 
 import charm
-from tests.scenario.helpers import get_charm_meta
 
 
 @pytest.fixture(autouse=True)
 def use_mock_config_path(mock_config_path):
     # Use the common mock_config_path fixture from conftest.py
     yield
-
-
-@pytest.fixture(autouse=True)
-def mock_snap():
-    """Mock the charm's snap property so we don't access the host."""
-    with patch("charm.GrafanaAgentMachineCharm.snap", new_callable=PropertyMock):
-        yield
 
 
 def test_juju_info_and_cos_agent(vroot):
@@ -56,7 +47,6 @@ def test_juju_info_and_cos_agent(vroot):
 
     context = Context(
         charm_type=charm.GrafanaAgentMachineCharm,
-        meta=get_charm_meta(charm.GrafanaAgentMachineCharm),
         charm_root=vroot,
     )
     state = State(
@@ -122,7 +112,6 @@ def test_two_cos_agent_relations(vroot):
 
     context = Context(
         charm_type=charm.GrafanaAgentMachineCharm,
-        meta=get_charm_meta(charm.GrafanaAgentMachineCharm),
         charm_root=vroot,
     )
     state = State(

--- a/tests/scenario/test_machine_charm/test_multiple_subordinates.py
+++ b/tests/scenario/test_machine_charm/test_multiple_subordinates.py
@@ -15,7 +15,7 @@ def use_mock_config_path(mock_config_path):
     yield
 
 
-def test_juju_info_and_cos_agent(vroot):
+def test_juju_info_and_cos_agent(vroot, charm_config):
     def post_event(charm: charm.GrafanaAgentMachineCharm):
         assert len(charm._cos.dashboards) == 1
         assert len(charm._cos.snap_log_endpoints) == 1
@@ -54,12 +54,13 @@ def test_juju_info_and_cos_agent(vroot):
             cos_agent_relation,
             SubordinateRelation("juju-info", remote_app_name="remote-juju-info"),
             PeerRelation("peers"),
-        ]
+        ],
+        config=charm_config,
     )
     context.run(event=cos_agent_relation.changed_event, state=state, post_event=post_event)
 
 
-def test_two_cos_agent_relations(vroot):
+def test_two_cos_agent_relations(vroot, charm_config):
     def post_event(charm: charm.GrafanaAgentMachineCharm):
         assert len(charm._cos.dashboards) == 2
         assert len(charm._cos.snap_log_endpoints) == 2
@@ -119,7 +120,8 @@ def test_two_cos_agent_relations(vroot):
             cos_agent_primary_relation,
             cos_agent_subordinate_relation,
             PeerRelation("peers"),
-        ]
+        ],
+        config=charm_config,
     )
     out_state = context.run(event=cos_agent_primary_relation.changed_event, state=state)
     vroot.clean()

--- a/tests/scenario/test_machine_charm/test_relation_priority.py
+++ b/tests/scenario/test_machine_charm/test_relation_priority.py
@@ -9,14 +9,12 @@ from cosl import GrafanaDashboard
 from scenario import Context, PeerRelation, State, SubordinateRelation
 
 import charm
-from tests.scenario.helpers import get_charm_meta
 from tests.scenario.test_machine_charm.helpers import set_run_out
 
 
 def trigger(evt: str, state: State, vroot: Path = None, **kwargs):
     context = Context(
         charm_type=charm.GrafanaAgentMachineCharm,
-        meta=get_charm_meta(charm.GrafanaAgentMachineCharm),
         charm_root=vroot,
     )
     return context.run(event=evt, state=state, **kwargs)
@@ -170,7 +168,6 @@ def test_both_relations(mock_run, vroot):
 
     context = Context(
         charm_type=charm.GrafanaAgentMachineCharm,
-        meta=get_charm_meta(charm.GrafanaAgentMachineCharm),
         charm_root=vroot,
     )
     state = State(

--- a/tests/scenario/test_machine_charm/test_relation_priority.py
+++ b/tests/scenario/test_machine_charm/test_relation_priority.py
@@ -32,7 +32,7 @@ def patch_all(placeholder_cfg_path):
 
 
 @patch("charm.subprocess.run")
-def test_no_relations(mock_run, vroot):
+def test_no_relations(mock_run, vroot, charm_config):
     def post_event(charm: charm.GrafanaAgentMachineCharm):
         assert not charm._cos.dashboards
         assert not charm._cos.logs_alerts
@@ -41,11 +41,11 @@ def test_no_relations(mock_run, vroot):
         assert not charm._cos.snap_log_endpoints
 
     set_run_out(mock_run, 0)
-    trigger("start", State(), post_event=post_event, vroot=vroot)
+    trigger("start", State(config=charm_config), post_event=post_event, vroot=vroot)
 
 
 @patch("charm.subprocess.run")
-def test_juju_info_relation(mock_run, vroot):
+def test_juju_info_relation(mock_run, vroot, charm_config):
     def post_event(charm: charm.GrafanaAgentMachineCharm):
         assert not charm._cos.dashboards
         assert not charm._cos.logs_alerts
@@ -61,7 +61,8 @@ def test_juju_info_relation(mock_run, vroot):
                 SubordinateRelation(
                     "juju-info", remote_unit_data={"config": json.dumps({"subordinate": True})}
                 )
-            ]
+            ],
+            config=charm_config,
         ),
         post_event=post_event,
         vroot=vroot,
@@ -69,7 +70,7 @@ def test_juju_info_relation(mock_run, vroot):
 
 
 @patch("charm.subprocess.run")
-def test_cos_machine_relation(mock_run, vroot):
+def test_cos_machine_relation(mock_run, vroot, charm_config):
     def post_event(charm: charm.GrafanaAgentMachineCharm):
         assert charm._cos.dashboards
         assert charm._cos.snap_log_endpoints
@@ -118,7 +119,8 @@ def test_cos_machine_relation(mock_run, vroot):
                     remote_unit_data=cos_agent_data,
                 ),
                 PeerRelation("peers", peers_data={1: peer_data}),
-            ]
+            ],
+            config=charm_config,
         ),
         post_event=post_event,
         vroot=vroot,
@@ -126,7 +128,7 @@ def test_cos_machine_relation(mock_run, vroot):
 
 
 @patch("charm.subprocess.run")
-def test_both_relations(mock_run, vroot):
+def test_both_relations(mock_run, vroot, charm_config):
     def post_event(charm: charm.GrafanaAgentMachineCharm):
         assert charm._cos.dashboards
         assert charm._cos.snap_log_endpoints
@@ -179,6 +181,7 @@ def test_both_relations(mock_run, vroot):
             ),
             SubordinateRelation("juju-info", remote_app_name="remote-juju-info"),
             PeerRelation("peers", peers_data={1: peer_data}),
-        ]
+        ],
+        config=charm_config,
     )
     context.run(event="start", state=state, post_event=post_event)

--- a/tests/scenario/test_machine_charm/test_scrape_configs.py
+++ b/tests/scenario/test_machine_charm/test_scrape_configs.py
@@ -30,7 +30,7 @@ def patch_all(placeholder_cfg_path):
 
 
 @pytest.mark.skip(reason="can't parse a custom fstab file")
-def test_snap_endpoints(placeholder_cfg_path):
+def test_snap_endpoints(placeholder_cfg_path, charm_config):
     written_path, written_text = "", ""
 
     def mock_write(_, path, text):
@@ -71,6 +71,7 @@ def test_snap_endpoints(placeholder_cfg_path):
         state = State(
             relations=[cos_relation, loki_relation, PeerRelation("peers")],
             model=Model(name="my-model", uuid=my_uuid),
+            config=charm_config,
         )
 
         ctx = Context(

--- a/tests/scenario/test_machine_charm/test_tracing_configuration.py
+++ b/tests/scenario/test_machine_charm/test_tracing_configuration.py
@@ -14,14 +14,14 @@ def test_cos_agent_receiver_protocols_match_with_tracing():
 
 @pytest.mark.parametrize("protocol", get_args(TracingReceiverProtocol))
 def test_always_enable_config_variables_are_generated_for_tracing_protocols(
-    protocol, vroot, mock_config_path
+    protocol, vroot, mock_config_path, charm_config
 ):
     context = Context(
         charm_type=GrafanaAgentMachineCharm,
         charm_root=vroot,
     )
     state = State(
-        config={f"always_enable_{protocol}": True},
+        config={f"always_enable_{protocol}": True, **charm_config},
         leader=True,
         relations=[],
     )

--- a/tests/scenario/test_machine_charm/test_tracing_configuration.py
+++ b/tests/scenario/test_machine_charm/test_tracing_configuration.py
@@ -13,7 +13,9 @@ def test_cos_agent_receiver_protocols_match_with_tracing():
 
 
 @pytest.mark.parametrize("protocol", get_args(TracingReceiverProtocol))
-def test_always_enable_config_variables_are_generated_for_tracing_protocols(protocol, vroot):
+def test_always_enable_config_variables_are_generated_for_tracing_protocols(
+    protocol, vroot, mock_config_path
+):
     context = Context(
         charm_type=GrafanaAgentMachineCharm,
         charm_root=vroot,

--- a/tests/unit/test_cloud_integration.py
+++ b/tests/unit/test_cloud_integration.py
@@ -30,6 +30,10 @@ class TestUpdateStatus(unittest.TestCase):
         self.mock_install = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = patch.object(GrafanaAgentCharm, "_verify_snap_track")
+        self.mock_verify_snap_track = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_prometheus_remote_write_config_with_grafana_cloud_integrator(self):
         """Asserts that the prometheus remote write config is written correctly for leaders and non-leaders."""
         for leader in (True, False):

--- a/tests/unit/test_relation_status.py
+++ b/tests/unit/test_relation_status.py
@@ -31,6 +31,10 @@ class TestRelationStatus(unittest.TestCase):
         self.mock_install = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = patch.object(GrafanaAgentCharm, "_verify_snap_track")
+        self.mock_verify_snap_track = patcher.start()
+        self.addCleanup(patcher.stop)
+
         self.harness = Harness(GrafanaAgentCharm)
         self.harness.set_model_name(self.__class__.__name__)
 

--- a/tests/unit/test_update_status.py
+++ b/tests/unit/test_update_status.py
@@ -30,6 +30,10 @@ class TestUpdateStatus(unittest.TestCase):
         self.mock_install = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = patch.object(GrafanaAgentCharm, "_verify_snap_track")
+        self.mock_verify_snap_track = patcher.start()
+        self.addCleanup(patcher.stop)
+
         self.harness = Harness(GrafanaAgentCharm)
         self.harness.set_model_name(self.__class__.__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,15 +18,6 @@ setenv =
   PYTHONBREAKPOINT=ipdb.set_trace
   PY_COLORS=1
 skip_install=True
-#passenv =
-#  PYTHONPATH
-#  HOME
-#  PATH
-#  CHARM_BUILD_DIR
-#  MODEL_SETTINGS
-#  HTTP_PROXY
-#  HTTPS_PROXY
-#  NO_PROXY
 
 [testenv:fmt]
 description = Apply coding style standards to code

--- a/tox.ini
+++ b/tox.ini
@@ -31,22 +31,20 @@ skip_install=True
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
-    black
     ruff
 commands =
+    ruff check --fix {[vars]all_path}
     ruff format {[vars]all_path}
-    black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
     ruff
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache --skip *.svg
     ruff check {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    ruff format --check {[vars]all_path}
 
 [testenv:static-{charm,lib}]
 description = Run static analysis checks

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
     black
     ruff
 commands =
-    ruff check --fix {[vars]all_path}
+    ruff format {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ deps =
     -r{toxinidir}/requirements.txt
     pytest
     cosl
-    ops-scenario>=6.1.5
+    ops-scenario~=6.1
 commands =
     pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/scenario/test_machine_charm
 


### PR DESCRIPTION
## Issue
We want to switch to using the classically confined snap by default, but continue to have strict as an option. This is because the strictly confined snap has problems getting everything it needs from the system.
fixes #52
fixes #23 

## Solution
Added a new "classic_snap" config option.

## Testing Instructions
Fiddle with the "classic_snap" variable. You can use `snap info --verbose grafana-agent | grep confinement` to check the confinement of the currently installed snap.


## Upgrade Notes
Now uses the classically confined grafana-agent snap.
