### PR TITLE
remove structured_metadata

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -456,12 +456,6 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                                     "expression": ".*file is a directory.*",
                                 },
                             },
-                            {
-                                "structured_metadata": {"filename": "filename"},
-                            },
-                            {
-                                "labeldrop": ["filename"],
-                            },
                         ],
                         "static_configs": [
                             {
@@ -482,12 +476,6 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                                 "drop": {
                                     "expression": ".*file is a directory.*",
                                 },
-                            },
-                            {
-                                "structured_metadata": {"filename": "filename"},
-                            },
-                            {
-                                "labeldrop": ["filename"],
                             },
                         ],
                     },


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Since we [have learn something that was not documented in Grafana docs](https://github.com/grafana/agent/pull/7026), which is that `grafana-agent` is not able to forward `structured_metadata` coming from `promtail` (or another `grafana-agent`) to `loki`

```
promtail --> grafana-agent --> loki
```

We are removing `structured_metadata` because the pipeline is not reliable. An administrator may wrongly think that because `promtail` sends `structured_metadata` it will reach `loki` when this is not always true. 
