### PR TITLE
Add drm collector to start having metrics from AMD GPUs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -418,6 +418,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                 else "/var/lib/snapd/hostfs",
                 "enabled": True,
                 "enable_collectors": [
+                    "drm",
                     "logind",
                     "systemd",
                     "mountstats",


### PR DESCRIPTION
## Issue
Start collecting GPU metrics for monitoring data centers that uses AMD GPUs


## Solution
Enable the `drm` collector that is disabled by default


## Context
Even that not all servers have AMD GPUs the impact in terms of performance for time of collecting metrics wasn't perceptive.

On a machine that does not have AMD GPUs it will barely increase the number of metrics:

```shell
# HELP node_drm_card_info Card information
# TYPE node_drm_card_info gauge
node_drm_card_info{card="card1",memory_vendor="",power_performance_level="",unique_id="",vendor="amd"} 1
node_drm_card_info{card="card2",memory_vendor="",power_performance_level="",unique_id="",vendor="amd"} 1
# HELP node_drm_gpu_busy_percent How busy the GPU is as a percentage.
# TYPE node_drm_gpu_busy_percent gauge
node_drm_gpu_busy_percent{card="card1"} 0
node_drm_gpu_busy_percent{card="card2"} 0
# HELP node_drm_memory_gtt_size_bytes The size of the graphics translation table (GTT) block in bytes.
# TYPE node_drm_memory_gtt_size_bytes gauge
node_drm_memory_gtt_size_bytes{card="card1"} 0
node_drm_memory_gtt_size_bytes{card="card2"} 0
# HELP node_drm_memory_gtt_used_bytes The used amount of the graphics translation table (GTT) block in bytes.
# TYPE node_drm_memory_gtt_used_bytes gauge
node_drm_memory_gtt_used_bytes{card="card1"} 0
node_drm_memory_gtt_used_bytes{card="card2"} 0
# HELP node_drm_memory_vis_vram_size_bytes The size of visible VRAM in bytes.
# TYPE node_drm_memory_vis_vram_size_bytes gauge
node_drm_memory_vis_vram_size_bytes{card="card1"} 0
node_drm_memory_vis_vram_size_bytes{card="card2"} 0
# HELP node_drm_memory_vis_vram_used_bytes The used amount of visible VRAM in bytes.
# TYPE node_drm_memory_vis_vram_used_bytes gauge
node_drm_memory_vis_vram_used_bytes{card="card1"} 0
node_drm_memory_vis_vram_used_bytes{card="card2"} 0
# HELP node_drm_memory_vram_size_bytes The size of VRAM in bytes.
# TYPE node_drm_memory_vram_size_bytes gauge
node_drm_memory_vram_size_bytes{card="card1"} 0
node_drm_memory_vram_size_bytes{card="card2"} 0
# HELP node_drm_memory_vram_used_bytes The used amount of VRAM in bytes.
# TYPE node_drm_memory_vram_used_bytes gauge
node_drm_memory_vram_used_bytes{card="card1"} 0
node_drm_memory_vram_used_bytes{card="card2"} 0
node_scrape_collector_duration_seconds{collector="drm"} 7.0185e-05
node_scrape_collector_success{collector="drm"} 1
```
