### PR TITLE
Traces downsampling policy

### DIFF
--- a/charmcraft-22.04.yaml
+++ b/charmcraft-22.04.yaml
@@ -175,24 +175,27 @@ config:
         even if there is no integration currently requesting it.
       type: boolean
       default: false
-    charm_traces_sampling_percentage:
+    tracing_sample_rate_charm:
       description: >
         This property defines the percentage of charm traces that are sent to tracing backend.
         Setting it to 100 would mean all charm traces are kept, setting to 0 means charm traces
-        aren't sent to tracing backend at all.
+        aren't sent to tracing backend at all. Anything outside of 0-100 range will be normalised 
+        to this range by Grafana Agent.
       type: float
       default: 100.0
-    workload_traces_sampling_percentage:
+    tracing_sample_rate_workload:
       description: >
         This property defines the percentage of workload traces that are sent to tracing backend.
         Setting it to 100 would mean all workload traces are kept, setting to 0 means workload traces
-        aren't sent to tracing backend at all.
+        aren't sent to tracing backend at all. Anything outside of 0-100 range will be normalised 
+        to this range by Grafana Agent.
       type: float
       default: 1.0
-    error_traces_sampling_percentage:
+    tracing_sample_rate_error:
       description: >
         This property defines the percentage of error traces (regardless of the type) that are sent to tracing backend.
         Setting it to 100 would mean all error traces are kept, setting to 0 means error traces
-        aren't sent to tracing backend at all.
+        aren't sent to tracing backend at all. Anything outside of 0-100 range will be normalised 
+        to this range by Grafana Agent.
       type: float
       default: 100.0

--- a/charmcraft-22.04.yaml
+++ b/charmcraft-22.04.yaml
@@ -175,3 +175,24 @@ config:
         even if there is no integration currently requesting it.
       type: boolean
       default: false
+    charm_traces_sampling_percentage:
+      description: >
+        This property defines the percentage of charm traces that are sent to tracing backend.
+        Setting it to 100 would mean all charm traces are kept, setting to 0 means charm traces
+        aren't sent to tracing backend at all.
+      type: float
+      default: 100.0
+    workload_traces_sampling_percentage:
+      description: >
+        This property defines the percentage of workload traces that are sent to tracing backend.
+        Setting it to 100 would mean all workload traces are kept, setting to 0 means workload traces
+        aren't sent to tracing backend at all.
+      type: float
+      default: 1.0
+    error_traces_sampling_percentage:
+      description: >
+        This property defines the percentage of error traces (regardless of the type) that are sent to tracing backend.
+        Setting it to 100 would mean all error traces are kept, setting to 0 means error traces
+        aren't sent to tracing backend at all.
+      type: float
+      default: 100.0

--- a/charmcraft-24.04.yaml
+++ b/charmcraft-24.04.yaml
@@ -140,3 +140,24 @@ config:
         even if there is no integration currently requesting it.
       type: boolean
       default: false
+    charm_traces_sampling_percentage:
+      description: >
+        This property defines the percentage of charm traces that are sent to tracing backend.
+        Setting it to 100 would mean all charm traces are kept, setting to 0 means charm traces
+        aren't sent to tracing backend at all.
+      type: float
+      default: 100.0
+    workload_traces_sampling_percentage:
+      description: >
+        This property defines the percentage of workload traces that are sent to tracing backend.
+        Setting it to 100 would mean all workload traces are kept, setting to 0 means workload traces
+        aren't sent to tracing backend at all.
+      type: float
+      default: 1.0
+    error_traces_sampling_percentage:
+      description: >
+        This property defines the percentage of error traces (regardless of the type) that are sent to tracing backend.
+        Setting it to 100 would mean all error traces are kept, setting to 0 means error traces
+        aren't sent to tracing backend at all.
+      type: float
+      default: 100.0

--- a/charmcraft-24.04.yaml
+++ b/charmcraft-24.04.yaml
@@ -140,24 +140,24 @@ config:
         even if there is no integration currently requesting it.
       type: boolean
       default: false
-    charm_traces_sampling_percentage:
+    tracing_sample_rate_charm:
       description: >
-        This property defines the percentage of charm traces that are sent to tracing backend.
+        This property defines the percentage of charm traces that are sent to the tracing backend.
         Setting it to 100 would mean all charm traces are kept, setting to 0 means charm traces
-        aren't sent to tracing backend at all.
+        aren't sent to the tracing backend at all.
       type: float
       default: 100.0
-    workload_traces_sampling_percentage:
+    tracing_sample_rate_workload:
       description: >
-        This property defines the percentage of workload traces that are sent to tracing backend.
+        This property defines the percentage of workload traces that are sent to the tracing backend.
         Setting it to 100 would mean all workload traces are kept, setting to 0 means workload traces
-        aren't sent to tracing backend at all.
+        aren't sent to the tracing backend at all.
       type: float
       default: 1.0
-    error_traces_sampling_percentage:
+    tracing_sample_rate_error:
       description: >
-        This property defines the percentage of error traces (regardless of the type) that are sent to tracing backend.
+        This property defines the percentage of error traces (from all sources) that are sent to the tracing backend.
         Setting it to 100 would mean all error traces are kept, setting to 0 means error traces
-        aren't sent to tracing backend at all.
+        aren't sent to the tracing backend at all.
       type: float
       default: 100.0

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -868,7 +868,6 @@ class GrafanaAgentCharm(CharmBase):
 
         return config
 
-
     @property
     def _tracing_sampling(self) -> Dict[str, Any]:
         return {
@@ -950,7 +949,6 @@ class GrafanaAgentCharm(CharmBase):
                 },
             ]
         }
-
 
     @property
     def _tempo_config(self) -> Dict[str, Union[Any, List[Any]]]:

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -870,6 +870,10 @@ class GrafanaAgentCharm(CharmBase):
 
     @property
     def _tracing_sampling(self) -> Dict[str, Any]:
+        # policies, as defined by tail sampling processor definition:
+        # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor
+        # each of them is evaluated separately and processor decides whether to pass the trace through or not
+        # see the description of tail sampling processor above for the full decision tree
         return {
             "policies": [
                 {
@@ -881,13 +885,15 @@ class GrafanaAgentCharm(CharmBase):
                                 "name": "trace-status-policy",
                                 "type": "status_code",
                                 "status_code": {"status_codes": ["ERROR"]},
+                                # status_code processor is using span_status property of spans within a trace
+                                # see https://opentelemetry.io/docs/concepts/signals/traces/#span-status for reference
                             },
                             {
                                 "name": "probabilistic-policy",
                                 "type": "probabilistic",
                                 "probabilistic": {
                                     "sampling_percentage": self.config.get(
-                                        "error_traces_sampling_percentage"
+                                        "tracing_sample_rate_error"
                                     )
                                 },
                             },
@@ -913,7 +919,7 @@ class GrafanaAgentCharm(CharmBase):
                                 "type": "probabilistic",
                                 "probabilistic": {
                                     "sampling_percentage": self.config.get(
-                                        "charm_traces_sampling_percentage"
+                                        "tracing_sample_rate_charm"
                                     )
                                 },
                             },
@@ -940,7 +946,7 @@ class GrafanaAgentCharm(CharmBase):
                                 "type": "probabilistic",
                                 "probabilistic": {
                                     "sampling_percentage": self.config.get(
-                                        "workload_traces_sampling_percentage"
+                                        "tracing_sample_rate_workload"
                                     )
                                 },
                             },

--- a/tests/scenario/test_machine_charm/test_tracing_configuration.py
+++ b/tests/scenario/test_machine_charm/test_tracing_configuration.py
@@ -1,11 +1,18 @@
 from typing import get_args
+from unittest.mock import patch
 
 import pytest
+import yaml
 from charms.grafana_agent.v0.cos_agent import ReceiverProtocol
 from charms.tempo_k8s.v2.tracing import ReceiverProtocol as TracingReceiverProtocol
-from scenario import Context, State
+from scenario import Context, Relation, State, SubordinateRelation
 
 from charm import GrafanaAgentMachineCharm
+from lib.charms.grafana_agent.v0.cos_agent import (
+    CosAgentProviderUnitData,
+    Receiver,
+)
+from lib.charms.tempo_k8s.v2.tracing import TracingProviderAppData
 
 
 def test_cos_agent_receiver_protocols_match_with_tracing():
@@ -28,3 +35,56 @@ def test_always_enable_config_variables_are_generated_for_tracing_protocols(
     with context.manager("config-changed", state) as mgr:
         charm: GrafanaAgentMachineCharm = mgr.charm
         assert protocol in charm.requested_tracing_protocols
+
+
+@pytest.mark.parametrize(
+    "sampling_config",
+    (
+        {
+            "always_enable_otlp_http": True,
+        },
+        {
+            "always_enable_otlp_http": True,
+            "tracing_sample_rate_charm": 23.0,
+            "tracing_sample_rate_workload": 13.13,
+            "tracing_sample_rate_error": 42.42,
+        },
+    ),
+)
+def test_tracing_sampling_config_is_present(
+    vroot, placeholder_cfg_path, mock_config_path, sampling_config
+):
+    # GIVEN a tracing relation over the tracing-provider endpoint and one over tracing
+    context = Context(
+        charm_type=GrafanaAgentMachineCharm,
+        charm_root=vroot,
+    )
+    tracing_provider = SubordinateRelation(
+        "cos-agent",
+        remote_unit_data=CosAgentProviderUnitData(
+            metrics_alert_rules={},
+            log_alert_rules={},
+            metrics_scrape_jobs=[],
+            log_slots=[],
+            dashboards=[],
+            subordinate=True,
+            tracing_protocols=["otlp_http", "otlp_grpc"],
+        ).dump(),
+    )
+    tracing = Relation(
+        "tracing",
+        remote_app_data=TracingProviderAppData(
+            receivers=[
+                Receiver(protocol={"name": "otlp_grpc", "type": "grpc"}, url="http:foo.com:1111")
+            ]
+        ).dump(),
+    )
+
+    state = State(leader=True, relations=[tracing, tracing_provider], config=sampling_config)
+    # WHEN we process any setup event for the relation
+    with patch("charm.GrafanaAgentMachineCharm.is_ready", True):
+        context.run("config_changed", state)
+
+    yml = yaml.safe_load(placeholder_cfg_path.read_text())
+
+    assert yml["traces"]["configs"][0]["tail_sampling"]


### PR DESCRIPTION
## Issue
Grafana-agent charm passes all traces to the tracing backend as it doesn't have any downsampling configuration.


## Solution
Add a sampling policy with three config variables, setting up sampling strategies for charm traces, workload traces and errors.


## Context
Grafana agent uses tail sampling processor from opentelemetry-collector, its reference is here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.96.0/processor/tailsamplingprocessor

Tandem PR: https://github.com/canonical/grafana-agent-k8s-operator/pull/319


## Testing Instructions
Run the following bundle in a machine model, using mysql-operator from [this branch](https://github.com/mmkay/mysql-operator/tree/tracing-in-cos-agent):
```
default-base: ubuntu@22.04/stable
saas:
  prometheus-receive-remote-write:
    url: microk8s:admin/welcome-k8s.prometheus-receive-remote-write
  tracing:
    url: microk8s:admin/welcome-k8s.tracing
applications:
  grafana-agent:
    charm: local:grafana-agent-0
    options:
      charm_traces_sampling_percentage: 100
  mysql:
    charm: local:mysql-0
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
    storage:
      database: rootfs,1,1024M
machines:
  "0":
    constraints: arch=amd64
relations:
- - grafana-agent:send-remote-write
  - prometheus-receive-remote-write:receive-remote-write
- - grafana-agent:tracing
  - tracing:tracing
- - mysql:cos-agent
  - grafana-agent:cos-agent
```

In another k8s model, deploy cos-lite + tempo:
```
bundle: kubernetes
saas:
  remote-f33b3981087c439185dc9e6c2cbb47d8: {}
applications:
  alertmanager:
    charm: alertmanager-k8s
    channel: latest/edge
    revision: 135
    base: ubuntu@20.04/stable
    resources:
      alertmanager-image: 98
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  catalogue:
    charm: catalogue-k8s
    channel: latest/edge
    revision: 63
    base: ubuntu@20.04/stable
    resources:
      catalogue-image: 34
    scale: 1
    options:
      description: "Canonical Observability Stack Lite, or COS Lite, is a light-weight,
        highly-integrated, \nJuju-based observability suite running on Kubernetes.\n"
      tagline: Model-driven Observability Stack deployed with a single command.
      title: Canonical Observability Stack
    constraints: arch=amd64
    trust: true
  grafana:
    charm: grafana-k8s
    channel: latest/edge
    revision: 119
    base: ubuntu@20.04/stable
    resources:
      grafana-image: 70
      litestream-image: 45
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: latest/edge
    revision: 171
    base: ubuntu@20.04/stable
    resources:
      loki-image: 100
      node-exporter-image: 3
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  prometheus:
    charm: prometheus-k8s
    channel: latest/edge
    revision: 212
    base: ubuntu@20.04/stable
    resources:
      prometheus-image: 150
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  tempo-k8s:
    charm: tempo-k8s
    channel: latest/edge
    revision: 83
    resources:
      tempo-image: 17
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  traefik:
    charm: traefik-k8s
    channel: latest/edge
    revision: 211
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 161
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - traefik:ingress-per-unit
  - prometheus:ingress
- - traefik:ingress-per-unit
  - loki:ingress
- - traefik:traefik-route
  - grafana:ingress
- - traefik:ingress
  - alertmanager:ingress
- - prometheus:alertmanager
  - alertmanager:alerting
- - grafana:grafana-source
  - prometheus:grafana-source
- - grafana:grafana-source
  - loki:grafana-source
- - grafana:grafana-source
  - alertmanager:grafana-source
- - loki:alertmanager
  - alertmanager:alerting
- - prometheus:metrics-endpoint
  - traefik:metrics-endpoint
- - prometheus:metrics-endpoint
  - alertmanager:self-metrics-endpoint
- - prometheus:metrics-endpoint
  - loki:metrics-endpoint
- - prometheus:metrics-endpoint
  - grafana:metrics-endpoint
- - grafana:grafana-dashboard
  - loki:grafana-dashboard
- - grafana:grafana-dashboard
  - prometheus:grafana-dashboard
- - grafana:grafana-dashboard
  - alertmanager:grafana-dashboard
- - catalogue:ingress
  - traefik:ingress
- - catalogue:catalogue
  - grafana:catalogue
- - catalogue:catalogue
  - prometheus:catalogue
- - catalogue:catalogue
  - alertmanager:catalogue
- - catalogue:catalogue
  - loki:catalogue
- - loki:logging
  - tempo-k8s:logging
- - loki:logging
  - traefik:logging
- - tempo-k8s:tracing
  - alertmanager:tracing
- - tempo-k8s:tracing
  - catalogue:tracing
- - tempo-k8s:grafana-dashboard
  - grafana:grafana-dashboard
- - tempo-k8s:grafana-source
  - grafana:grafana-source
- - tempo-k8s:tracing
  - grafana:tracing
- - tempo-k8s:tracing
  - loki:tracing
- - tempo-k8s:metrics-endpoint
  - prometheus:metrics-endpoint
- - tempo-k8s:tracing
  - prometheus:tracing
- - tempo-k8s:tracing
  - traefik:tracing
- - traefik:grafana-dashboard
  - grafana:grafana-dashboard
- - traefik:traefik-route
  - tempo-k8s:ingress
- - prometheus:receive-remote-write
  - remote-f33b3981087c439185dc9e6c2cbb47d8:send-remote-write
- - tempo-k8s:tracing
  - remote-f33b3981087c439185dc9e6c2cbb47d8:tracing
--- # overlay.yaml
applications:
  prometheus:
    offers:
      prometheus-receive-remote-write:
        endpoints:
        - receive-remote-write
        acl:
          admin: admin
  tempo-k8s:
    offers:
      tracing:
        endpoints:
        - tracing
        acl:
          admin: admin
```

Use juju config to change charm tracing configuration:
```
juju config grafana-agent charm_traces_sampling_percentage=0
```

Observe that no new charm traces appear, then:

```
juju config grafana-agent charm_traces_sampling_percentage=100
```

Observe that charm traces started appearing again.


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
