### PR TITLE
update cloud_config_requirer lib

### DIFF
--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -6,7 +6,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "e6f580481c1b4388aa4d2cdf412a47fa"
 LIBAPI = 0
-LIBPATCH = 6
+LIBPATCH = 7
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
@@ -83,16 +83,8 @@ class GrafanaCloudConfigRequirer(Object):
     @property
     def credentials(self):
         """Return the credentials, if any; otherwise, return None."""
-        if not all(
-            self._is_not_empty(x)
-            for x in [
-                self._data.get("username", ""),
-                self._data.get("password", ""),
-            ]):
-                return Credentials(
-                    self._data.get("username", ""),
-                    self._data.get("password", "")
-                )
+        if (username := self._data.get("username", "").strip()) and (password := self._data.get("password", "").strip()):
+            return Credentials(username, password)
         return None
 
     @property

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,8 @@ deps =
     asyncstdlib
     # Libjuju needs to track the juju version
     juju ~= 3.3.0
+    # https://github.com/juju/python-libjuju/issues/1184
+    websockets<14.0
     # Temporarily pinning pytest due to https://github.com/charmed-kubernetes/pytest-operator/issues/131
     pytest ~= 8.1.1
     prometheus-api-client


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR fixes #203


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Pack the charm, and deploy this bundle:

```yaml
default-base: ubuntu@22.04/stable
applications:
  agent:
    charm: local:grafana-agent-0
  grafana-cloud-integrator:
    charm: grafana-cloud-integrator
    channel: latest/edge
    revision: 21
    num_units: 1
    to:
    - "1"
    options:
      loki-url: http://loki.com
      password: Password
      username: Username
    constraints: arch=amd64
  ubuntu:
    charm: ubuntu
    channel: latest/stable
    revision: 25
    num_units: 3
    to:
    - "2"
    - "3"
    - "4"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "1":
    constraints: arch=amd64
  "2":
    constraints: arch=amd64
  "3":
    constraints: arch=amd64
  "4":
    constraints: arch=amd64
relations:
- - ubuntu:juju-info
  - agent:juju-info
- - grafana-cloud-integrator:grafana-cloud-config
  - agent:grafana-cloud-config
```

then, verify that in every `grafana-agent` config file, `username` and `password` are inside `logs` section, for instance:

```yaml
logs:
  configs:
  - clients:
    - basic_auth:
        password: Password
        username: Username
      headers:
        Content-Encoding: snappy
      tls_config:
        insecure_skip_verify: false
      url: http://loki.com
```