### PR TITLE
feat: support external ca from cloud-integrator

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -19,10 +19,9 @@ from charms.operator_libs_linux.v2 import snap  # type: ignore
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from cosl import JujuTopology
 from cosl.rules import AlertRules
+from grafana_agent import METRICS_RULES_SRC_PATH, GrafanaAgentCharm
 from ops.main import main
 from ops.model import BlockedStatus, MaintenanceStatus, Relation
-
-from grafana_agent import METRICS_RULES_SRC_PATH, GrafanaAgentCharm
 from snap_management import SnapSpecError, install_ga_snap
 
 logger = logging.getLogger(__name__)

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,9 +19,10 @@ from charms.operator_libs_linux.v2 import snap  # type: ignore
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from cosl import JujuTopology
 from cosl.rules import AlertRules
-from grafana_agent import METRICS_RULES_SRC_PATH, GrafanaAgentCharm
 from ops.main import main
 from ops.model import BlockedStatus, MaintenanceStatus, Relation
+
+from grafana_agent import METRICS_RULES_SRC_PATH, GrafanaAgentCharm
 from snap_management import SnapSpecError, install_ga_snap
 
 logger = logging.getLogger(__name__)

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -89,6 +89,7 @@ class GrafanaAgentCharm(CharmBase):
     _snap_key_path = "/var/snap/grafana-agent/common/grafana-agent.key"
     _snap_ca_path = "/var/snap/grafana-agent/common/grafana-agent-operator.crt"
     _snap_folder_path = "/var/snap/grafana-agent/common/"
+    # We have a `limit: 1` on the cloud integrator relation so we expect only one such cert.
     _cloud_ca_path = "/usr/local/share/ca-certificates/cloud-integrator.crt"
 
     # mapping from tempo-supported receivers to the receiver ports to be opened on the grafana-agent host


### PR DESCRIPTION
## Issue
This PR partially is in tandem with the PR https://github.com/canonical/grafana-cloud-integrator/pull/21 and should be merged after.

It also fixes (partially) https://github.com/canonical/grafana-cloud-integrator/issues/18 (I'm also opening a PR in the k8s charm).

⚠️ Do NOT merge before the other one, it contains the (yet) unreleased version of the `cloud_config_requirer` library.

## Solution

**grafana-cloud-integrator#21** (the PR for the CA issue) is addressed by saving the CA coming from relation data to file, and then calling `update-ca-certificates` as usual. We do this on the custom `cloud-config-available` event, which is emitted whenever there is a relation joined/changed/broken involving the cloud-integrator relation.

**grafana-cloud-integrator#18** (the config issue) is solved by populating the `_loki_config` not only if there are endpoints coming from `self._loki_consumer`, but also considering the ones coming from the cloud integrator (`self._cloud.loki_ready`). The endpoints themselves are already included in `self._loki_endpoints_with_tls()`.

## Testing Instructions
The code is exactly the same as for the k8s charm, but feel free to replicate the testing instructions with the grafana-agent machine charm.