### PR TITLE
Disable charm trace buffer

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -156,6 +156,7 @@ class GrafanaAgentServiceError(GrafanaAgentError):
     tracing_endpoint="_charm_tracing_endpoint",
     server_cert="_server_cert",
     extra_types=(COSAgentRequirer, JujuTopology, SnapFstab),
+    buffer_max_events=0,
 )
 class GrafanaAgentMachineCharm(GrafanaAgentCharm):
     """Machine version of the Grafana Agent charm."""


### PR DESCRIPTION
## Issue
An addition of charm tracing buffer means that a file with traces buffer attempts to create. If that file fails to create (as the environment might be blocking creating new files), we likely would get an error. 


## Solution
<!-- A summary of the solution addressing the above issue -->
Disable charm tracing buffer in grafana-agent charm so that it doesn't break in the scenario above.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
See also https://github.com/canonical/tempo-coordinator-k8s-operator/issues/73


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Deploy the example bundle:
```
default-base: ubuntu@22.04/stable
saas:
  prometheus-receive-remote-write:
    url: microk8s:admin/test-tempo.prometheus-receive-remote-write
applications:
  grafana-agent:
    charm: grafana-agent
    channel: latest/edge
    revision: 301
  zookeeper:
    charm: zookeeper
    channel: 3/stable
    revision: 149
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
    storage:
      data: rootfs,1,1024M
machines:
  "0":
    constraints: arch=amd64
relations:
- - zookeeper:cos-agent
  - grafana-agent:cos-agent
- - grafana-agent:send-remote-write
  - prometheus-receive-remote-write:receive-remote-write
```
then pack grafana-agent from this branch and refresh the `grafana-agent` charm. It should still be up and not fail on the upgrade event.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
