### PR TITLE
fix: remove group name repetition from alerts

### DIFF
--- a/src/prometheus_alert_rules/oomkill.rules
+++ b/src/prometheus_alert_rules/oomkill.rules
@@ -1,5 +1,5 @@
 groups:
-- name: HostMemory
+- name: HostOomkill
   rules:
   - alert: HostOomKillDetected
     expr: increase(node_vmstat_oom_kill[1h]) > 0


### PR DESCRIPTION
## Issue
Alert rules won't reach Prometheus because they fail validation. Specifically, the group name `HostMemory` is used both in `oomkill.rules` and in `memory.rules`.


## Solution
Change the group name of the `oomkill.rules` file, so it doesn't clash with the one in `memory.rules`.