### PR TITLE
 Use a binary PyYAML package

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -62,6 +62,10 @@ parts:
     - pkg-config
     - rustc
     - cargo
+    charm-binary-python-packages:
+      # Install PyYAML from binary and avoid building it from sources. This way, we can use PyYAML with C-optimized lib.
+      # With the C-optimized lib, serialization in ops is 20x faster.
+      - PyYAML
   cos-tool:
     plugin: dump
     source: .


### PR DESCRIPTION
## Issue
grafana agent charm may have quite some reldata to pipe through, and updating many relations may take some time, because the pyyaml we end up using isn't optimized.


## Solution
Use a binary pyyaml package.

In tandem with https://github.com/canonical/grafana-agent-k8s-operator/pull/332.

## Context
https://github.com/canonical/cos-proxy-operator/pull/150