### PR TITLE
Specify default py version for ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ show_missing = true
 [tool.ruff]
 line-length = 99
 exclude = ["__pycache__", "*.egg_info"]
+target-version = "py38"
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]


### PR DESCRIPTION
## Issue
`tox -e fmt` passes without changes, but `tox -e lint` [fails](https://github.com/canonical/grafana-agent-operator/actions/runs/11978290330).


## Solution
Specify python target version for ruff.


## Context
https://github.com/astral-sh/ruff/pull/13896
