### PR TITLE
feat: add exclude-list for logs in /var/log

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -210,3 +210,10 @@ config:
         Ref: https://grafana.com/docs/agent/latest/static/configuration/flags/#report-information-usage
       type: boolean
       default: true
+    exclude_files:
+      description: >
+        Glob for a set of log files that should be ignored by Grafana Agent.
+        For example, `/var/log/**/{app_one,app_two}.log` will result in the agent ignoring both 
+        `/var/log/app_one.log` and `/var/log/app_two.log`.
+      type: string
+      default: ""

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -217,6 +217,10 @@ config:
         For example, `/var/log/**/{app_one,app_two}.log` will result in the agent ignoring both 
         `/var/log/app_one.log` and `/var/log/app_two.log`.
 
+        Note that the value you provide here is not interpreted as a path, but rather as a glob matcher.
+        Specifically, if you want to exclude logs in the `/var/log/test` folder, you should set the 
+        config to `/var/log/test/**`.
+
         Ref (__path_exclude__): https://grafana.com/docs/loki/latest/send-data/promtail/scraping/
       type: string
       default: ""

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -210,7 +210,7 @@ config:
         Ref: https://grafana.com/docs/agent/latest/static/configuration/flags/#report-information-usage
       type: boolean
       default: true
-    exclude_files:
+    path_exclude:
       description: >
         Glob for a set of log files present in `/var/log` that should be ignored by Grafana Agent.
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -212,8 +212,11 @@ config:
       default: true
     exclude_files:
       description: >
-        Glob for a set of log files that should be ignored by Grafana Agent.
+        Glob for a set of log files present in `/var/log` that should be ignored by Grafana Agent.
+
         For example, `/var/log/**/{app_one,app_two}.log` will result in the agent ignoring both 
         `/var/log/app_one.log` and `/var/log/app_two.log`.
+
+        Ref (__path_exclude__): https://grafana.com/docs/loki/latest/send-data/promtail/scraping/
       type: string
       default: ""

--- a/src/charm.py
+++ b/src/charm.py
@@ -474,6 +474,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                                 "targets": ["localhost"],
                                 "labels": {
                                     "__path__": "/var/log/**/*log",
+                                    "__path_exclude__": self.model.config.get("exclude_files"),
                                     "job": "varlog",
                                     **self._own_labels,
                                 },

--- a/src/charm.py
+++ b/src/charm.py
@@ -474,7 +474,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                                 "targets": ["localhost"],
                                 "labels": {
                                     "__path__": "/var/log/**/*log",
-                                    "__path_exclude__": self.model.config.get("exclude_files"),
+                                    "__path_exclude__": self.model.config.get("path_exclude"),
                                     "job": "varlog",
                                     **self._own_labels,
                                 },


### PR DESCRIPTION
## Issue

Closes #48.

## Solution

Grafana Agent scrapes all the log files under `/var/log` via a scrape job that defines `__path__: /var/log/**/*.log`. The scrape job definition allows defining a `__path_exclude__` key at the same level, allowing a Glob pattern matching to exclude files from the scrape.

This PR allows users to set that `__path_exclude__` key with a config option.

## Testing instructions

1. Deploy Grafana Agent (with `juju config agent exclude_files="some/glob") + Zookeeper on machine, Loki + Traefik + Grafana (to use as Loki UI) on k8s.
2. Create a file under the excluded path.
3. Verify the log doesn't appear in Loki.