### PR TITLE
chore: bump LIBPATCH for cos_agent

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -252,7 +252,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["cosl", "pydantic"]
 


### PR DESCRIPTION
Bump LIBPATCH because [this commit](https://github.com/canonical/grafana-agent-operator/commit/00a71be918731428657f4e1f482386b17b5e0549) was directly pushed to main by mistake.

