### PR TITLE
Remove log pollution from charm tracing in scenario tests

### DIFF
--- a/tests/scenario/test_machine_charm/conftest.py
+++ b/tests/scenario/test_machine_charm/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import PropertyMock, patch
 import pytest
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 
+
 @pytest.fixture
 def placeholder_cfg_path(tmp_path):
     return tmp_path / "foo.yaml"

--- a/tests/scenario/test_machine_charm/conftest.py
+++ b/tests/scenario/test_machine_charm/conftest.py
@@ -3,7 +3,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 
 @pytest.fixture
 def placeholder_cfg_path(tmp_path):
@@ -39,3 +39,9 @@ CONFIG_MATRIX = [
 @pytest.fixture(params=CONFIG_MATRIX)
 def charm_config(request):
     return request.param
+
+
+@pytest.fixture(autouse=True)
+def mock_charm_tracing():
+    with charm_tracing_disabled():
+        yield

--- a/tests/scenario/test_machine_charm/test_tracing_configuration.py
+++ b/tests/scenario/test_machine_charm/test_tracing_configuration.py
@@ -5,7 +5,6 @@ import pytest
 import yaml
 from charms.grafana_agent.v0.cos_agent import ReceiverProtocol
 from charms.tempo_coordinator_k8s.v0.tracing import ReceiverProtocol as TracingReceiverProtocol
-from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 from scenario import Context, Relation, State, SubordinateRelation
 
 from charm import GrafanaAgentMachineCharm
@@ -77,7 +76,9 @@ def test_tracing_sampling_config_is_present(
         remote_app_data=TracingProviderAppData(
             receivers=[
                 Receiver(protocol={"name": "otlp_grpc", "type": "grpc"}, url="http:foo.com:1111"),
-                Receiver(protocol={"name": "otlp_http", "type": "http"}, url="http://localhost:1112"),
+                Receiver(
+                    protocol={"name": "otlp_http", "type": "http"}, url="http://localhost:1112"
+                ),
             ]
         ).dump(),
     )

--- a/tests/scenario/test_machine_charm/test_tracing_configuration.py
+++ b/tests/scenario/test_machine_charm/test_tracing_configuration.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 from charms.grafana_agent.v0.cos_agent import ReceiverProtocol
 from charms.tempo_coordinator_k8s.v0.tracing import ReceiverProtocol as TracingReceiverProtocol
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 from scenario import Context, Relation, State, SubordinateRelation
 
 from charm import GrafanaAgentMachineCharm
@@ -75,7 +76,8 @@ def test_tracing_sampling_config_is_present(
         "tracing",
         remote_app_data=TracingProviderAppData(
             receivers=[
-                Receiver(protocol={"name": "otlp_grpc", "type": "grpc"}, url="http:foo.com:1111")
+                Receiver(protocol={"name": "otlp_grpc", "type": "grpc"}, url="http:foo.com:1111"),
+                Receiver(protocol={"name": "otlp_http", "type": "http"}, url="http://localhost:1112"),
             ]
         ).dump(),
     )


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
In scenario test runs, a significant number of warnings (and some error logs) came from the fact that charm tracing was enabled even though there isn't anything charm traces can be sent to. 

```
WARNING  tracing:charm_tracing.py:658 <class 'charm.GrafanaAgentMachineCharm'>._server_cert is None; sending traces over INSECURE connection.
WARNING  opentelemetry.trace:__init__.py:537 Overriding of current TracerProvider is not allowed
WARNING  opentelemetry.sdk.trace.export:__init__.py:213 Already shutdown, dropping span.
WARNING  opentelemetry.sdk.trace.export:__init__.py:213 Already shutdown, dropping span.
WARNING  opentelemetry.sdk.trace.export:__init__.py:213 Already shutdown, dropping span.
WARNING  opentelemetry.sdk.trace.export:__init__.py:213 Already shutdown, dropping span.
WARNING  opentelemetry.sdk.trace.export:__init__.py:213 Already shutdown, dropping span.
WARNING  opentelemetry.sdk.trace.export:__init__.py:213 Already shutdown, dropping span.
```


## Solution
<!-- A summary of the solution addressing the above issue -->
Disable charm tracing in all scenario tests as we aren't testing charm tracing there. We're testing tracing-related configuration in one set of tests, but this doesn't need charm tracing to be enabled.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Run `tox -e scenario` and see the log pollution decreased significantly.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
