### PR TITLE
feat: add hugepages into the HostMemoryFull alert expression

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -252,7 +252,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 12
+LIBPATCH = 13
 
 PYDEPS = ["cosl", "pydantic"]
 
@@ -767,7 +767,7 @@ class COSAgentProvider(Object):
         """Is this endpoint ready?"""
         relation = relation or self._relation
         if not relation:
-            logger.debug(f"no relation on {self._relation_name !r}: tracing not ready")
+            logger.debug(f"no relation on {self._relation_name!r}: tracing not ready")
             return False
         if relation.data is None:
             logger.error(f"relation data is None for {relation}")
@@ -1029,8 +1029,7 @@ class COSAgentRequirer(Object):
         if len(units) > 1:
             # should never happen
             raise ValueError(
-                f"unexpected error: subordinate relation {relation} "
-                f"should have exactly one unit"
+                f"unexpected error: subordinate relation {relation} should have exactly one unit"
             )
 
         unit = next(iter(units), None)

--- a/src/prometheus_alert_rules/memory.rules
+++ b/src/prometheus_alert_rules/memory.rules
@@ -35,6 +35,7 @@ groups:
           LABELS = {{ $labels }}
         The 5-minute-ahead prediction is made as a linear regression from the last 30 minutes of data.
   - alert: HostMemoryFull
+    # The difference of averages is more robust (less noisy) than computing the average at the end
     expr: |
       100 * avg_over_time(node_memory_MemFree_bytes[1m]) /
         (

--- a/src/prometheus_alert_rules/memory.rules
+++ b/src/prometheus_alert_rules/memory.rules
@@ -36,17 +36,11 @@ groups:
         The 5-minute-ahead prediction is made as a linear regression from the last 30 minutes of data.
   - alert: HostMemoryFull
     expr: |
-      100 *
-        (
-          (
-            avg_over_time(node_memory_MemTotal_bytes[1m])
-            - avg_over_time(node_memory_MemFree_bytes[1m])
-          ) - avg_over_time(node_memory_Hugetlb_bytes[1m])
-        ) /
+      100 * avg_over_time(node_memory_MemFree_bytes[1m]) /
         (
           avg_over_time(node_memory_MemTotal_bytes[1m])
           - avg_over_time(node_memory_Hugetlb_bytes[1m])
-        ) > 90
+        ) < 10
     for: 2m
     labels:
       severity: critical

--- a/src/prometheus_alert_rules/memory.rules
+++ b/src/prometheus_alert_rules/memory.rules
@@ -35,7 +35,18 @@ groups:
           LABELS = {{ $labels }}
         The 5-minute-ahead prediction is made as a linear regression from the last 30 minutes of data.
   - alert: HostMemoryFull
-    expr: avg_over_time(node_memory_MemUsed_percentage[1m]) > 95
+    expr: |
+      100 *
+        (
+          (
+            avg_over_time(node_memory_MemTotal_bytes[1m])
+            - avg_over_time(node_memory_MemFree_bytes[1m])
+          ) - avg_over_time(node_memory_Hugetlb_bytes[1m])
+        ) /
+        (
+          avg_over_time(node_memory_MemTotal_bytes[1m])
+          - avg_over_time(node_memory_Hugetlb_bytes[1m])
+        ) > 90
     for: 2m
     labels:
       severity: critical

--- a/tests/scenario/test_alert_labels.py
+++ b/tests/scenario/test_alert_labels.py
@@ -120,7 +120,7 @@ def test_metrics_alert_rule_labels(charm_config):
     )
     for group in alert_rules["groups"]:
         for rule in group["rules"]:
-            if "grafana-agent_alertgroup_alerts" in group["name"]:
+            if "grafana_agent_alertgroup_alerts" in group["name"]:
                 assert (
                     rule["labels"]["juju_application"] == "primary"
                     or rule["labels"]["juju_application"] == "subordinate"


### PR DESCRIPTION
## Issue
Closes #41.


## Solution

> [!warning]
> I had to bump the `cos_agent` library because of a linting error which was auto-fixed by `tox -e fmt`.

Modify the alert expression as detailed in the issue. The expression was flipped because there is a `MemFree_bytes` metric, but not a `MemUsed_bytes` one.

TL;DR (see comments in the yaml below):
```yaml
expr: |
      100 * avg_over_time(node_memory_MemFree_bytes[1m]) /
        (
          avg_over_time(node_memory_MemTotal_bytes[1m])
          - avg_over_time(node_memory_Hugetlb_bytes[1m])
        ) < 10
```

Here's a visual representation:

🔴 Pre-allocated HugePages memory (`node_memory_Hugetlb_bytes`)
🟣 Memory used *outside of HugePages* (`node_memory_MemTotal_bytes - node_memory_Hugetlb_bytes`)
🔵 Available memory (`node_memory_MemFree_bytes`)

🔴 + 🟣 = `node_memory_MemTotal_bytes`

**Memory:** 🔴🔴🔴🔴🔴🔴🔴🟣🟣🟣🟣🔵🔵

The alert is checking that 🔵/🟣 is less than 10%.

-