### PR TITLE
fix: update cos-tool permissions to adhere to cis hardening rules

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -73,7 +73,7 @@ parts:
       - curl
     override-pull: |
       curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_ARCH_BUILD_FOR}
-      chmod +x cos-tool-*
+      chmod 775 cos-tool-*
 
 requires:
   certificates:

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -252,7 +252,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 12
+LIBPATCH = 13
 
 PYDEPS = ["cosl", "pydantic"]
 
@@ -767,7 +767,7 @@ class COSAgentProvider(Object):
         """Is this endpoint ready?"""
         relation = relation or self._relation
         if not relation:
-            logger.debug(f"no relation on {self._relation_name !r}: tracing not ready")
+            logger.debug(f"no relation on {self._relation_name!r}: tracing not ready")
             return False
         if relation.data is None:
             logger.error(f"relation data is None for {relation}")
@@ -1029,8 +1029,7 @@ class COSAgentRequirer(Object):
         if len(units) > 1:
             # should never happen
             raise ValueError(
-                f"unexpected error: subordinate relation {relation} "
-                f"should have exactly one unit"
+                f"unexpected error: subordinate relation {relation} should have exactly one unit"
             )
 
         unit = next(iter(units), None)

--- a/tests/scenario/test_alert_labels.py
+++ b/tests/scenario/test_alert_labels.py
@@ -120,7 +120,7 @@ def test_metrics_alert_rule_labels(charm_config):
     )
     for group in alert_rules["groups"]:
         for rule in group["rules"]:
-            if "grafana-agent_alertgroup_alerts" in group["name"]:
+            if "grafana_agent_alertgroup_alerts" in group["name"]:
                 assert (
                     rule["labels"]["juju_application"] == "primary"
                     or rule["labels"]["juju_application"] == "subordinate"


### PR DESCRIPTION
## Issue
Closes #208.
In tandem with: https://github.com/canonical/grafana-agent-k8s-operator/pull/341.

## Solution
Fix the `cos-tool` permissions according to the linked issue (removing the *write* permission from *others*).

> [!warning]
> I had to bump the `cos_agent` library because of a linting error which was auto-fixed by `tox -e fmt`.

We change the `cos-tool` permissions with `path.chmod(0o777)` in multiple places:
- lib/charms/loki_k8s/v1/loki_push_api.py
- lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
- lib/charms/grafana_k8s/v0/grafana_dashboard.py
- lib/charms/prometheus_k8s/v0/prometheus_scrape.py

We need three PRs in Prometheus, Loki and Grafana to fix those libraries:
- https://github.com/canonical/prometheus-k8s-operator/pull/664
- https://github.com/canonical/grafana-k8s-operator/pull/371
- https://github.com/canonical/loki-k8s-operator/pull/485

I manually changed the library files, packed the charm, and tested with the `juju ssh grafana-agent/X -- sudo find / -xdev -type f -perm -002` command, and no file with too many permissions is returned anymore.

## Testing Instructions

```bash
charmcraft pack
juju deploy ./(grafana-agent-charm)
juju deploy zookeeper --base ubuntu@22.04
juju relate grafana-agent zookeeper

# wait for it to settle

# Look for files with too many permissions (see issue)
# Make sure this returns nothing
juju ssh grafana-agent/X -- sudo find / -xdev -type f -perm -002
```
