### PR TITLE
fix: apply HostDiskSpace alert to all relevant mountpoints

### DIFF
--- a/src/prometheus_alert_rules/disk.rules
+++ b/src/prometheus_alert_rules/disk.rules
@@ -19,7 +19,7 @@ groups:
           LABELS = {{ $labels }}
         The 6-hour-ahead prediction is made as a linear regression from the last 60 minutes of data.
   - alert: HostDiskSpace
-    expr: used_disk_space{mountpoint=~"/"} > 90
+    expr: used_disk_space{fstype!~"fuse.lxcfs|fuse.snapfuse", mountpoint!~"/run.*|/proc|/dev"} > 90
     for: 0m
     labels:
       severity: critical

--- a/src/prometheus_alert_rules/disk.rules
+++ b/src/prometheus_alert_rules/disk.rules
@@ -19,7 +19,8 @@ groups:
           LABELS = {{ $labels }}
         The 6-hour-ahead prediction is made as a linear regression from the last 60 minutes of data.
   - alert: HostDiskSpace
-    expr: used_disk_space{fstype!~"fuse.lxcfs|fuse.snapfuse", mountpoint!~"/run.*|/proc|/dev"} > 90
+    # some fstype are excluded because they are not relevant; see https://github.com/canonical/grafana-agent-k8s-operator/pull/340 for details
+    expr: used_disk_space{fstype!~"fuse\.lxcfs|fuse\.snapfuse", mountpoint!~"/run.*|/proc|/dev"} > 90
     for: 0m
     labels:
       severity: critical

--- a/src/prometheus_alert_rules/disk.rules
+++ b/src/prometheus_alert_rules/disk.rules
@@ -19,7 +19,7 @@ groups:
           LABELS = {{ $labels }}
         The 6-hour-ahead prediction is made as a linear regression from the last 60 minutes of data.
   - alert: HostDiskSpace
-    # some fstype are excluded because they are not relevant; see https://github.com/canonical/grafana-agent-k8s-operator/pull/340 for details
+    # some fstype are excluded because they are not relevant; see https://github.com/canonical/grafana-agent-operator/pull/233 for details
     expr: used_disk_space{fstype!~"fuse\.lxcfs|fuse\.snapfuse", mountpoint!~"/run.*|/proc|/dev"} > 90
     for: 0m
     labels:


### PR DESCRIPTION
## Issue
[grafana-agent-k8s#331](https://github.com/canonical/grafana-agent-k8s-operator/issues/331)


## Solution
Update the alert to include all mountpoints (removing the `mountpoint~="/"` filter), but excluding irrelevant mountpoints:
- `fstype: fuse.lxcfs` is always NaN (confirmed by the LXD team)
- `fstype: fuse.snapfuse` is always 100%
- `/run`, `/proc`, and `/dev` are not relevant
