### PR TITLE
Add note about limit: 1 for the provider.

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -8,6 +8,7 @@ This library can be used to manage the cos_agent relation interface:
 - `COSAgentProvider`: Use in machine charms that need to have a workload's metrics
   or logs scraped, or forward rule files or dashboards to Prometheus, Loki or Grafana through
   the Grafana Agent machine charm.
+  NOTE: Be sure to add `limit: 1` in your charm for the cos-agent relation.
 
 - `COSAgentConsumer`: Used in the Grafana Agent machine charm to manage the requirer side of
   the `cos_agent` interface.
@@ -252,7 +253,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 15
+LIBPATCH = 16
 
 PYDEPS = ["cosl", "pydantic"]
 

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -8,7 +8,8 @@ This library can be used to manage the cos_agent relation interface:
 - `COSAgentProvider`: Use in machine charms that need to have a workload's metrics
   or logs scraped, or forward rule files or dashboards to Prometheus, Loki or Grafana through
   the Grafana Agent machine charm.
-  NOTE: Be sure to add `limit: 1` in your charm for the cos-agent relation.
+  NOTE: Be sure to add `limit: 1` in your charm for the cos-agent relation. That is the only
+   way we currently have to prevent two different grafana agent apps deployed on the same VM.
 
 - `COSAgentConsumer`: Used in the Grafana Agent machine charm to manage the requirer side of
   the `cos_agent` interface.


### PR DESCRIPTION
## Issue
Deploying two grafana agent instances on the same VM is not supported, but we cannot prevent it.
One way this could be prevented indirectly is if the principal charm has a "limit: 1" for the cos-agent relation. 


## Solution
Add note in docstring encouraging users to add a "limit: 1".
