### PR TITLE
fix: have HostMemoryFull alert use MemAvailable instead of MemFree

### DIFF
--- a/src/prometheus_alert_rules/memory.rules
+++ b/src/prometheus_alert_rules/memory.rules
@@ -37,7 +37,7 @@ groups:
   - alert: HostMemoryFull
     # The difference of averages is more robust (less noisy) than computing the average at the end
     expr: |
-      100 * avg_over_time(node_memory_MemFree_bytes[1m]) /
+      100 * avg_over_time(node_memory_MemAvailable_bytes[1m]) /
         (
           avg_over_time(node_memory_MemTotal_bytes[1m])
           - avg_over_time(node_memory_Hugetlb_bytes[1m])


### PR DESCRIPTION
## Issue
Closes #247.


## Solution
Use `MemAvailable` instead of `MemFree` in the alert.


## Context
> **MemFree_bytes**: Theamount of physical RAM left unused by the system.
> **MemAvailable_bytes**: An estimate of how much memory is available for starting new applications, without swapping.
