### PR TITLE
feat(charmcraft): switch to the uv plugin

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: grafana-agent
@@ -25,22 +25,27 @@ platforms:
 
 parts:
   charm:
-    charm-binary-python-packages: 
-      # Install PyYAML from binary and avoid building it from sources. This way, we can use PyYAML with C-optimized lib.
-      # With the C-optimized lib, serialization in ops is 20x faster.
-      - PyYAML
-      - cryptography
-      - jsonschema
-      - pydantic
-      - pydantic-core
+    # Uncomment the commented out portions of this part to build from source.
+    source: .
+    plugin: uv
+    # build-environment:
+    #   - UV_NO_BINARY: "true"
+    #   - MAKEOPTS: -j$(nproc)  # Use all available cores for building pyyaml
+    # override-pull: |
+    #   craftctl default
+    #   rustup default 1.84
     build-packages:
+      # - libffi-dev
+      # - libssl-dev
+      # - libyaml-dev
+      # - pkg-config
       - git
-    build-snaps: [astral-uv]
+    build-snaps:
+      - astral-uv
+      # - rustup
     override-build: |
-      uv export --frozen --no-hashes --format=requirements-txt -o requirements.txt
-      git describe --always > version
       craftctl default
-    charm-requirements: [requirements.txt]
+      git describe --always > $CRAFT_PART_INSTALL/version
   cos-tool:
     plugin: dump
     source: .


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The charm gets built using the old, slow, somewhat-weird `charm` plugin

## Solution
<!-- A summary of the solution addressing the above issue -->
This switches the charm to use the new uv plugin available since Charmcraft 3.3. Due to https://github.com/astral-sh/uv/issues/11963 it simply uses binaries, but I've included a way to build entirely from source.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Sparked by a question by @sed-i in the Charmcraft matrix channel

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Ensure that the packed charm works the same as before :-)
This includes ensuring that it uses the optimised C-compiled version of pyyaml.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
n/a

## Further details

On my machine, the charm as-is packs all three amd64 platforms from scratch in under 3 minutes:

```terminal
$ time charmcraft pack
Packed grafana-agent_ubuntu@20.04-amd64.charm
Packed grafana-agent_ubuntu@22.04-amd64.charm
Packed grafana-agent_ubuntu@24.04-amd64.charm

real    2m57.678s
user    0m9.707s
sys     0m12.150s
```

Enabling build from source (which includes building `cryptography`, `pyyaml`, etc. from source), a clean build takes just under 18 minutes:

```terminal
$ time charmcraft pack
Packed grafana-agent_ubuntu@20.04-amd64.charm
Packed grafana-agent_ubuntu@22.04-amd64.charm
Packed grafana-agent_ubuntu@24.04-amd64.charm

real    17m36.875s
user    0m10.115s
sys     0m12.445s
```

Because of how charmcraft and uv do caching, the local build is primarily hit by a "first build" cost, where the first time building after `charmcraft clean` requires the full build. Subsequent builds, even fully from source, are far quicker:

```terminal
$ time charmcraft pack
Packed grafana-agent_ubuntu@20.04-amd64.charm
Packed grafana-agent_ubuntu@22.04-amd64.charm
Packed grafana-agent_ubuntu@24.04-amd64.charm

real    1m43.578s
user    0m6.483s
sys     0m7.689s
```
