### PR TITLE
feat(charmcraft): get cos-tool directly

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -29,7 +29,7 @@ parts:
       # Install PyYAML from binary and avoid building it from sources. This way, we can use PyYAML with C-optimized lib.
       # With the C-optimized lib, serialization in ops is 20x faster.
       - PyYAML
-      - cryptography==44.0.1
+      - cryptography
       - jsonschema
       - pydantic
       - pydantic-core

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -29,7 +29,7 @@ parts:
       # Install PyYAML from binary and avoid building it from sources. This way, we can use PyYAML with C-optimized lib.
       # With the C-optimized lib, serialization in ops is 20x faster.
       - PyYAML
-      - cryptography
+      - cryptography==44.0.1
       - jsonschema
       - pydantic
       - pydantic-core
@@ -43,11 +43,8 @@ parts:
     charm-requirements: [requirements.txt]
   cos-tool:
     plugin: dump
-    source: .
-    build-packages:
-      - curl
-    override-pull: |
-      curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_ARCH_BUILD_FOR}
+    source: https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_ARCH_BUILD_FOR}
+    source-type: file
     permissions:
       - path: cos-tool-${CRAFT_ARCH_BUILD_FOR}
         mode: "755"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The `charmcraft.yaml` file unnecessarily installs and uses `curl` rather than using the `dump` plugin directly

## Solution
<!-- A summary of the solution addressing the above issue -->
This grabs the `cos-tool` release directly into the dump plugin rather than installing curl and using that. The net effect should be the same.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
I guess my specialised knowledge is the details about how parts work.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Ensure that `cos-tool-*` in the charm still has the same permissions (looks like it to me):
![image](https://github.com/user-attachments/assets/01ff2deb-aa04-42fa-b1d8-d8d407f0b438)


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
n/a