### PR TITLE
fix: loki alert rule to reference the correct job name

### DIFF
--- a/src/loki_alert_rules/high_error_rate.rule
+++ b/src/loki_alert_rules/high_error_rate.rule
@@ -1,5 +1,5 @@
 alert: HostHighLogErrorRate
-expr: count_over_time({job="varlogs"} |= "error" [1h]) > 100
+expr: count_over_time({job="varlog"} |= "error" [1h]) > 100
 for: 0m
 labels:
   severity: warning


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
fixes https://github.com/canonical/grafana-agent-operator/issues/276

## Solution
<!-- A summary of the solution addressing the above issue -->
Update the job name in the query to reference the correct job name: `varlog`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
> [!WARNING]
>  This may trigger a lot of alerts to fire for large deployments like ps6 since the alert threshold is arbitrary

From [conversations with ManSol](https://chat.canonical.com/canonical/pl/s4bm9643oinpbjkcwem6ttfoxh), we should fix this bug and let the alerts fire for these large deployments and let them create an issue so we have use cases for changing the threshold or improving the alert.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
See the linked issue

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
