### PR TITLE
feat: add extra_alert_labels as a juju config option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -227,3 +227,8 @@ config:
         Toggle forwarding of alert rules.
       type: boolean
       default: true
+    extra_alert_labels:
+      description: >
+        Comma separated key-value pairs of labels to be added to all alerts.
+        This could be useful for differentiating between staging and production environments.
+      type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,7 +11,7 @@ import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union, get_args
+from typing import Any, Dict, List, Optional, Set, Union, cast, get_args
 
 import yaml
 from charms.grafana_agent.v0.cos_agent import COSAgentRequirer, ReceiverProtocol
@@ -47,13 +47,16 @@ def key_value_pair_string_to_dict(key_value_pair: str) -> dict:
             sep = "="
         else:
             logger.error("Invalid pair without separator ':' or '=': '%s'", pair)
+            continue
 
         key, value = map(str.strip, pair.split(sep, 1))
 
         if not key:
             logger.error("Empty key in pair: '%s'", pair)
+            continue
         if not value:
             logger.error("Empty value in pair: '%s'", pair)
+            continue
 
         result[key] = value
 
@@ -370,7 +373,8 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         """Return a list of metrics rules."""
         rules = self._cos.metrics_alerts
         topology = JujuTopology.from_charm(self)
-        extra_alert_labels = key_value_pair_string_to_dict(str(self.model.config.get("extra_alert_labels", "")))
+
+        extra_alert_labels = key_value_pair_string_to_dict(cast(str, self.model.config.get("extra_alert_labels", "")))
 
         # Get the rules defined by Grafana Agent itself.
         own_rules = AlertRules(query_type="promql", topology=topology)

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,7 +46,7 @@ def key_value_pair_string_to_dict(key_value_pair: str) -> dict:
         elif "=" in pair:
             sep = "="
         else:
-            logger.error("Invalid pair without separator ':' o '=': '%s'", pair)
+            logger.error("Invalid pair without separator ':' or '=': '%s'", pair)
 
         key, value = map(str.strip, pair.split(sep, 1))
 

--- a/tests/unit/test_alert_labels.py
+++ b/tests/unit/test_alert_labels.py
@@ -8,6 +8,78 @@ from ops.testing import Context, PeerRelation, Relation, State, SubordinateRelat
 
 import charm
 
+cos_agent_primary_data = {
+    "config": json.dumps(
+        {
+            "subordinate": False,
+            "metrics_alert_rules": {
+                "groups": [
+                    {
+                        "name": "alertgroup",
+                        "rules": [
+                            {
+                                "alert": "Missing",
+                                "expr": "up == 0",
+                                "for": "0m",
+                                "labels": {
+                                    "juju_model": "machine",
+                                    "juju_model_uuid": "74a5690b-89c9-44dd-984b-f69f26a6b751",
+                                    "juju_application": "primary",
+                                },
+                            }
+                        ],
+                    }
+                ]
+            },
+            "log_alert_rules": {},
+            "dashboards": [
+                "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQAmCnsKICAidGl0bGUiOiAi"
+                "Zm9vIiwKICAiYmFyIiA6ICJiYXoiCn0KAACkcc0YFt15xAABPyd8KlLdH7bzfQEAAAAABFla"
+            ],
+            "metrics_scrape_jobs": [
+                {"job_name": "primary_0", "path": "/metrics", "port": "8080"}
+            ],
+            "log_slots": ["foo:bar"],
+        }
+    )
+}
+
+cos_agent_subordinate_data = {
+    "config": json.dumps(
+        {
+            "subordinate": True,
+            "metrics_alert_rules": {
+                "groups": [
+                    {
+                        "name": "alertgroup",
+                        "rules": [
+                            {
+                                "alert": "Missing",
+                                "expr": "up == 0",
+                                "for": "0m",
+                                "labels": {
+                                    "juju_model": "machine",
+                                    "juju_model_uuid": "74a5690b-89c9-44dd-984b-f69f26a6b751",
+                                    "juju_application": "subordinate",
+                                },
+                            }
+                        ],
+                    }
+                ]
+            },
+            "log_alert_rules": {},
+            "dashboards": [
+                "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQAmCnsKICAidGl0bGUiOiAi"
+                "Zm9vIiwKICAiYmFyIiA6ICJiYXoiCn0KAACkcc0YFt15xAABPyd8KlLdH7bzfQEAAAAABFla"
+            ],
+            "metrics_scrape_jobs": [
+                {"job_name": "subordinate_0", "path": "/metrics", "port": "8081"}
+            ],
+            "log_slots": ["oh:snap"],
+        }
+    )
+}
+
 
 @pytest.fixture(autouse=True)
 def use_mock_config_path(mock_config_path):
@@ -17,78 +89,6 @@ def use_mock_config_path(mock_config_path):
 
 def test_metrics_alert_rule_labels(charm_config):
     """Check that metrics alert rules are labeled with principal topology."""
-    cos_agent_primary_data = {
-        "config": json.dumps(
-            {
-                "subordinate": False,
-                "metrics_alert_rules": {
-                    "groups": [
-                        {
-                            "name": "alertgroup",
-                            "rules": [
-                                {
-                                    "alert": "Missing",
-                                    "expr": "up == 0",
-                                    "for": "0m",
-                                    "labels": {
-                                        "juju_model": "machine",
-                                        "juju_model_uuid": "74a5690b-89c9-44dd-984b-f69f26a6b751",
-                                        "juju_application": "primary",
-                                    },
-                                }
-                            ],
-                        }
-                    ]
-                },
-                "log_alert_rules": {},
-                "dashboards": [
-                    "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQAmCnsKICAidGl0bGUiOiAi"
-                    "Zm9vIiwKICAiYmFyIiA6ICJiYXoiCn0KAACkcc0YFt15xAABPyd8KlLdH7bzfQEAAAAABFla"
-                ],
-                "metrics_scrape_jobs": [
-                    {"job_name": "primary_0", "path": "/metrics", "port": "8080"}
-                ],
-                "log_slots": ["foo:bar"],
-            }
-        )
-    }
-
-    cos_agent_subordinate_data = {
-        "config": json.dumps(
-            {
-                "subordinate": True,
-                "metrics_alert_rules": {
-                    "groups": [
-                        {
-                            "name": "alertgroup",
-                            "rules": [
-                                {
-                                    "alert": "Missing",
-                                    "expr": "up == 0",
-                                    "for": "0m",
-                                    "labels": {
-                                        "juju_model": "machine",
-                                        "juju_model_uuid": "74a5690b-89c9-44dd-984b-f69f26a6b751",
-                                        "juju_application": "subordinate",
-                                    },
-                                }
-                            ],
-                        }
-                    ]
-                },
-                "log_alert_rules": {},
-                "dashboards": [
-                    "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQAmCnsKICAidGl0bGUiOiAi"
-                    "Zm9vIiwKICAiYmFyIiA6ICJiYXoiCn0KAACkcc0YFt15xAABPyd8KlLdH7bzfQEAAAAABFla"
-                ],
-                "metrics_scrape_jobs": [
-                    {"job_name": "subordinate_0", "path": "/metrics", "port": "8081"}
-                ],
-                "log_slots": ["oh:snap"],
-            }
-        )
-    }
-
     cos_agent_primary_relation = SubordinateRelation(
         "cos-agent", remote_app_name="primary", remote_unit_data=cos_agent_primary_data
     )
@@ -123,6 +123,7 @@ def test_metrics_alert_rule_labels(charm_config):
     alert_rules = json.loads(
         state_2.get_relation(remote_write_relation.id).local_app_data["alert_rules"]
     )
+
     for group in alert_rules["groups"]:
         for rule in group["rules"]:
             if "grafana_agent_alertgroup_alerts" in group["name"]:
@@ -132,3 +133,87 @@ def test_metrics_alert_rule_labels(charm_config):
                 )
             else:
                 assert rule["labels"]["juju_application"] == "grafana-agent"
+
+
+def test_extra_alerts_config():
+    # GIVEN a new key-value pair of extra alerts labels, for instance:
+    # juju config agent extra_alerts_labels="environment: PRODUCTION, zone=Mars"
+
+    config1 = {"extra_alert_labels": "environment: PRODUCTION, zone=Mars",}
+
+    # THEN The extra_alert_labels MUST be added to the alert rules.
+    cos_agent_primary_relation = SubordinateRelation(
+        "cos-agent", remote_app_name="primary", remote_unit_data=cos_agent_primary_data
+    )
+    cos_agent_subordinate_relation = SubordinateRelation(
+        "cos-agent", remote_app_name="subordinate", remote_unit_data=cos_agent_subordinate_data
+    )
+    remote_write_relation = Relation("send-remote-write", remote_app_name="prometheus")
+
+    ctx = Context(
+        charm_type=charm.GrafanaAgentMachineCharm,
+    )
+    state = State(
+        leader=True,
+        relations=[
+            cos_agent_primary_relation,
+            cos_agent_subordinate_relation,
+            remote_write_relation,
+            PeerRelation("peers"),
+        ],
+        config=config1, # type: ignore
+    )
+
+    state_0 = ctx.run(ctx.on.relation_changed(relation=cos_agent_primary_relation), state)
+    state_1 = ctx.run(
+        ctx.on.relation_changed(relation=state_0.get_relation(cos_agent_subordinate_relation.id)),
+        state_0,
+    )
+    state_2 = ctx.run(
+        ctx.on.relation_joined(relation=state_1.get_relation(remote_write_relation.id)), state_1
+    )
+
+    alert_rules = json.loads(
+        state_2.get_relation(remote_write_relation.id).local_app_data["alert_rules"]
+    )
+
+    for group in alert_rules["groups"]:
+        for rule in group["rules"]:
+            if "grafana_agent_alertgroup_alerts" in group["name"]:
+                assert rule["labels"]["environment"] == "PRODUCTION"
+                assert rule["labels"]["zone"] == "Mars"
+                assert (
+                    rule["labels"]["juju_application"] == "primary"
+                    or rule["labels"]["juju_application"] == "subordinate"
+                )
+
+
+
+    # GIVEN the config option for extra alert labels is unset
+    config2 = {}
+
+    # THEN the only labels present in the alert are the JujuTopology labels
+    new_state = State(
+        leader=True,
+        relations=[
+            cos_agent_primary_relation,
+            cos_agent_subordinate_relation,
+            remote_write_relation,
+            PeerRelation("peers"),
+        ],
+        config=config2,
+    )
+    state_3 = ctx.run(ctx.on.config_changed(), new_state)
+    alert_rules = json.loads(
+        state_3.get_relation(remote_write_relation.id).local_app_data["alert_rules"]
+    )
+
+    for group in alert_rules["groups"]:
+        for rule in group["rules"]:
+            if "grafana_agent_alertgroup_alerts" in group["name"]:
+                assert rule["labels"].get("environment") is None
+                assert rule["labels"].get("zone") is None
+                assert (
+                    rule["labels"]["juju_application"] == "primary"
+                    or rule["labels"]["juju_application"] == "subordinate"
+                )


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR fixes: https://github.com/canonical/cos-configuration-k8s-operator/issues/113

## Solution
<!-- A summary of the solution addressing the above issue -->

In this PR we implement a new config option for grafana-agent, `extra_alert_labels`

```
Comma separated key-value pairs of labels to be added to all alerts.
This could be useful for differentiating between staging and production environments.
```


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

[Ref](https://github.com/canonical/cos-configuration-k8s-operator/issues/113): 
> COS currently uses a model in which prometheus alerts are created and managed by the charm developers.
However, this is a generalist solution that doesn't apply to all teams, all environments or all situations.
> 
> Sometimes, we want to add or remove a label depending on the environment stage (production/staging/dev).
Or maybe we want to prioritize business critical environments, and decrease the severity for other environments.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

### Testing

Just run the tests ;-)

### Manual Testing

1. Deploy grafana-agent
2. Deploy a Principal charm (say [zookeeper](https://charmhub.io/zookeeper))
3. Relate both charms through the `cos-agent` interface
4. Consume prometheus `receive-remote-write` offer from a Promethues charm deployed in a K8s model
5. Relate grafana-agent to prometheus
6. Add two new comma separated key-value pairs of labels to alert rules this way:
   ```
   juju config agent extra_alert_labels="environment: production, planet=mars"
   ```

    *Note that you can you can use `:` or `=`*

7. Verify that these labels are injected in the alert rules

![image](https://github.com/user-attachments/assets/892b8490-7059-48b0-b01c-9c58b6f74953)

8. Remove these labels by running:
   ```
   juju config agent extra_alert_labels=""
   ```
9. Verify that these labels were removed from the alert rules

![image](https://github.com/user-attachments/assets/397360d6-31b0-487e-b60b-098081460913)


### Bundle for manual testing

```yaml
default-base: ubuntu@22.04/stable
saas:
  prom:
    url: microk8s:admin/otel.prom
applications:
  agent:
    charm: local:grafana-agent-22
    options:
      extra_alert_labels: 'environment: production, planet=mars'
  zoo:
    charm: zookeeper
    channel: 3/stable
    revision: 149
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
    storage:
      data: rootfs,1,1024M
machines:
  "0":
    constraints: arch=amd64
relations:
- - zoo:cos-agent
  - agent:cos-agent
- - agent:send-remote-write
  - prom:receive-remote-write

```

