### PR TITLE
fix: add extra_alert_labels for injected generic alerts

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -190,10 +190,7 @@ The `LokiPushApiConsumer` constructor requires two things:
   with its clients. If provided, this relation name must match a required
   relation in metadata.yaml with the `loki_push_api` interface.
 
-  This argument is not required if your metadata.yaml has precisely one
-  required relation in metadata.yaml with the `loki_push_api` interface, as the
-  lib will automatically resolve the relation name inspecting the using the
-  meta information of the charm
+  If not provided, the relation name defaults to `logging`.
 
 Any time the relation between a Loki provider charm and a Loki consumer charm is
 established, a `LokiPushApiEndpointJoined` event is fired. In the consumer side
@@ -546,7 +543,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 17
+LIBPATCH = 18
 
 PYDEPS = ["cosl"]
 

--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -67,6 +67,8 @@ topology = JujuTopology(
 ```
 
 """
+
+import warnings
 from collections import OrderedDict
 from typing import Dict, List, Optional
 from uuid import UUID
@@ -75,7 +77,7 @@ from uuid import UUID
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 class InvalidUUIDError(Exception):
@@ -119,6 +121,13 @@ class JujuTopology:
             unit: a unit name as a string
             charm_name: name of charm as a string
         """
+        warnings.warn(
+            """
+            observability_libs.v0.juju_topology is deprecated. Please import the
+            library from `cosl` instead: https://github.com/canonical/cos-lib
+            """,
+            DeprecationWarning,
+        )
         if not self.is_valid_uuid(model_uuid):
             raise InvalidUUIDError(model_uuid)
 
@@ -215,7 +224,8 @@ class JujuTopology:
 
         if remapped_keys:
             ret = OrderedDict(
-                (remapped_keys.get(k), v) if remapped_keys.get(k) else (k, v) for k, v in ret.items()  # type: ignore
+                (remapped_keys.get(k), v) if remapped_keys.get(k) else (k, v)
+                for k, v in ret.items()  # type: ignore
             )
 
         return ret

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1189,15 +1189,21 @@ class MetricsEndpointConsumer(Object):
         """Returns a mapping from unit names to (address, path) tuples, for the given relation."""
         hosts = {}
         for unit in relation.units:
+            if not (unit_databag := relation.data.get(unit)):
+                continue
+
+            unit_path = unit_databag.get("prometheus_scrape_unit_path", "")
             # TODO deprecate and remove unit.name
-            unit_name = relation.data[unit].get("prometheus_scrape_unit_name") or unit.name
+            unit_name = unit_databag.get("prometheus_scrape_unit_name") or unit.name
             # TODO deprecate and remove "prometheus_scrape_host"
-            unit_address = relation.data[unit].get(
-                "prometheus_scrape_unit_address"
-            ) or relation.data[unit].get("prometheus_scrape_host")
-            unit_path = relation.data[unit].get("prometheus_scrape_unit_path", "")
-            if unit_name and unit_address:
-                hosts.update({unit_name: (unit_address, unit_path)})
+            unit_address = unit_databag.get("prometheus_scrape_unit_address") or unit_databag.get(
+                "prometheus_scrape_host"
+            )
+
+            if not (unit_name and unit_address):
+                continue
+
+            hosts.update({unit_name: (unit_address, unit_path)})
 
         return hosts
 
@@ -2043,10 +2049,12 @@ class MetricsEndpointAggregator(Object):
         """
         targets = {}
         for unit in relation.units:
-            port = relation.data[unit].get("port", 80)
-            hostname = relation.data[unit].get("hostname")
-            if hostname:
-                targets.update({unit.name: {"hostname": hostname, "port": port}})
+            if not (unit_databag := relation.data.get(unit)):
+                continue
+            if not (hostname := unit_databag.get("hostname")):
+                continue
+            port = unit_databag.get("port", 80)
+            targets.update({unit.name: {"hostname": hostname, "port": port}})
 
         return targets
 
@@ -2263,9 +2271,12 @@ class MetricsEndpointAggregator(Object):
         """
         rules = {}
         for unit in relation.units:
-            unit_rules = yaml.safe_load(relation.data[unit].get("groups", ""))
-            if unit_rules:
-                rules.update({unit.name: unit_rules})
+            if not (unit_databag := relation.data.get(unit)):
+                continue
+            if not (unit_rules := yaml.safe_load(unit_databag.get("groups", ""))):
+                continue
+
+            rules.update({unit.name: unit_rules})
 
         return rules
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 53
+LIBPATCH = 54
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1547,7 +1547,8 @@ class MetricsEndpointProvider(Object):
         if self._forward_alert_rules:
             alert_rules.add_path(self._alert_rules_path, recursive=True)
             alert_rules.add(
-                copy.deepcopy(generic_alert_groups.application_rules), group_name_prefix=self.topology.identifier
+                copy.deepcopy(generic_alert_groups.application_rules),
+                group_name_prefix=self.topology.identifier,
             )
         alert_rules_as_dict = alert_rules.as_dict()
 

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -13,6 +13,7 @@ the Prometheus remote_write API, that is, they can receive metrics data over rem
 should use the `PrometheusRemoteWriteProducer`.
 """
 
+import copy
 import json
 import logging
 import os
@@ -46,7 +47,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = ["cosl"]
 
@@ -404,6 +405,7 @@ class PrometheusRemoteWriteConsumer(Object):
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         *,
         forward_alert_rules: bool = True,
+        extra_alert_labels: Dict = {},
     ):
         """API to manage a required relation with the `prometheus_remote_write` interface.
 
@@ -415,6 +417,7 @@ class PrometheusRemoteWriteConsumer(Object):
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-set alerts data.
             forward_alert_rules: Flag to toggle forwarding of charmed alert rules.
+            extra_alert_labels: Dict of extra labels to inject alert rules with.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -444,6 +447,7 @@ class PrometheusRemoteWriteConsumer(Object):
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
         self._forward_alert_rules = forward_alert_rules
+        self._extra_alert_labels = extra_alert_labels
 
         self.topology = JujuTopology.from_charm(charm)
 
@@ -504,11 +508,27 @@ class PrometheusRemoteWriteConsumer(Object):
 
         alert_rules_as_dict = alert_rules.as_dict()
 
+        if self._extra_alert_labels:
+            alert_rules_as_dict = (
+                PrometheusRemoteWriteConsumer._inject_extra_labels_to_alert_rules(
+                    alert_rules_as_dict, self._extra_alert_labels
+                )
+            )
+
         relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def reload_alerts(self) -> None:
         """Reload alert rules from disk and push to relation data."""
         self._push_alerts_to_all_relation_databags(None)
+
+    @staticmethod
+    def _inject_extra_labels_to_alert_rules(rules: Dict, extra_alert_labels: Dict) -> Dict:
+        """Return a copy of the rules dict with extra labels injected."""
+        result = copy.deepcopy(rules)
+        for group in result.get("groups", []):
+            for rule in group.get("rules", []):
+                rule.setdefault("labels", {}).update(extra_alert_labels)
+        return result
 
     @property
     def endpoints(self) -> List[Dict[str, str]]:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -13,7 +13,6 @@ the Prometheus remote_write API, that is, they can receive metrics data over rem
 should use the `PrometheusRemoteWriteProducer`.
 """
 
-import copy
 import json
 import logging
 import os
@@ -47,7 +46,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["cosl"]
 
@@ -405,7 +404,6 @@ class PrometheusRemoteWriteConsumer(Object):
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         *,
         forward_alert_rules: bool = True,
-        extra_alert_labels: Dict = {},
     ):
         """API to manage a required relation with the `prometheus_remote_write` interface.
 
@@ -446,7 +444,6 @@ class PrometheusRemoteWriteConsumer(Object):
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
         self._forward_alert_rules = forward_alert_rules
-        self._extra_alert_labels = extra_alert_labels
 
         self.topology = JujuTopology.from_charm(charm)
 
@@ -507,27 +504,11 @@ class PrometheusRemoteWriteConsumer(Object):
 
         alert_rules_as_dict = alert_rules.as_dict()
 
-        if self._extra_alert_labels:
-            alert_rules_as_dict = (
-                PrometheusRemoteWriteConsumer._inject_extra_labels_to_alert_rules(
-                    alert_rules_as_dict, self._extra_alert_labels
-                )
-            )
-
         relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def reload_alerts(self) -> None:
         """Reload alert rules from disk and push to relation data."""
         self._push_alerts_to_all_relation_databags(None)
-
-    @staticmethod
-    def _inject_extra_labels_to_alert_rules(rules: Dict, extra_alert_labels: Dict) -> Dict:
-        """Return a copy of the rules dict with extra labels injected."""
-        result = copy.deepcopy(rules)
-        for group in result.get("groups", []):
-            for rule in group.get("rules", []):
-                rule.setdefault("labels", {}).update(extra_alert_labels)
-        return result
 
     @property
     def endpoints(self) -> List[Dict[str, str]]:
@@ -548,15 +529,17 @@ class PrometheusRemoteWriteConsumer(Object):
                 if unit.app is self._charm.app:
                     # This is a peer unit
                     continue
+                if not (unit_databag := relation.data.get(unit)):
+                    continue
+                if not (remote_write := unit_databag.get("remote_write")):
+                    continue
 
-                remote_write = relation.data[unit].get("remote_write")
-                if remote_write:
-                    deserialized_remote_write = json.loads(remote_write)
-                    endpoints.append(
-                        {
-                            "url": deserialized_remote_write["url"],
-                        }
-                    )
+                deserialized_remote_write = json.loads(remote_write)
+                endpoints.append(
+                    {
+                        "url": deserialized_remote_write["url"],
+                    }
+                )
 
         # When multiple units of the remote-write server are behind an ingress
         # (e.g. mimir), relation data would end up with the same ingress url

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -13,6 +13,7 @@ the Prometheus remote_write API, that is, they can receive metrics data over rem
 should use the `PrometheusRemoteWriteProducer`.
 """
 
+import copy
 import json
 import logging
 import os
@@ -404,6 +405,7 @@ class PrometheusRemoteWriteConsumer(Object):
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         *,
         forward_alert_rules: bool = True,
+        extra_alert_labels: Dict = {},
     ):
         """API to manage a required relation with the `prometheus_remote_write` interface.
 
@@ -444,6 +446,7 @@ class PrometheusRemoteWriteConsumer(Object):
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
         self._forward_alert_rules = forward_alert_rules
+        self._extra_alert_labels = extra_alert_labels
 
         self.topology = JujuTopology.from_charm(charm)
 
@@ -504,11 +507,28 @@ class PrometheusRemoteWriteConsumer(Object):
 
         alert_rules_as_dict = alert_rules.as_dict()
 
+        if self._extra_alert_labels:
+            alert_rules_as_dict = (
+                PrometheusRemoteWriteConsumer._inject_extra_labels_to_alert_rules(
+                    alert_rules_as_dict, self._extra_alert_labels
+                )
+            )
+
         relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def reload_alerts(self) -> None:
         """Reload alert rules from disk and push to relation data."""
         self._push_alerts_to_all_relation_databags(None)
+
+    @staticmethod
+    def _inject_extra_labels_to_alert_rules(rules: Dict, extra_alert_labels: Dict) -> Dict:
+        """Return a copy of the rules dict with extra labels injected."""
+        result = copy.deepcopy(rules)
+        for item in result.values():
+            for group in item.get("groups", []):
+                for rule in group.get("rules", []):
+                    rule.setdefault("labels", {}).update(extra_alert_labels)
+        return result
 
     @property
     def endpoints(self) -> List[Dict[str, str]]:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -524,10 +524,9 @@ class PrometheusRemoteWriteConsumer(Object):
     def _inject_extra_labels_to_alert_rules(rules: Dict, extra_alert_labels: Dict) -> Dict:
         """Return a copy of the rules dict with extra labels injected."""
         result = copy.deepcopy(rules)
-        for item in result.values():
-            for group in item.get("groups", []):
-                for rule in group.get("rules", []):
-                    rule.setdefault("labels", {}).update(extra_alert_labels)
+        for group in result.get("groups", []):
+            for rule in group.get("rules", []):
+                rule.setdefault("labels", {}).update(extra_alert_labels)
         return result
 
     @property

--- a/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -313,10 +313,10 @@ from typing import (
 
 import opentelemetry
 import ops
-from opentelemetry.exporter.otlp.proto.common._internal.trace_encoder import (
+from opentelemetry.exporter.otlp.proto.common._internal.trace_encoder import ( # type: ignore
     encode_spans # type: ignore
 )
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter  # type: ignore
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan, Span, TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -348,7 +348,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 

--- a/lib/charms/tempo_coordinator_k8s/v0/tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tracing.py
@@ -110,7 +110,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH =  8
+LIBPATCH =  9
 
 PYDEPS = ["pydantic"]
 
@@ -383,7 +383,7 @@ class Receiver(BaseModel):
     )
 
 
-class TracingProviderAppData(DatabagModel):  # noqa: D101
+class TracingProviderAppData(DatabagModel):  # noqa: D101 # type: ignore
     """Application databag model for the tracing provider."""
 
     receivers: List[Receiver] = Field(
@@ -392,7 +392,7 @@ class TracingProviderAppData(DatabagModel):  # noqa: D101
     )
 
 
-class TracingRequirerAppData(DatabagModel):  # noqa: D101
+class TracingRequirerAppData(DatabagModel):  # noqa: D101 # type: ignore
     """Application databag model for the tracing requirer."""
 
     receivers: List[ReceiverProtocol]

--- a/src/charm.py
+++ b/src/charm.py
@@ -38,16 +38,6 @@ _MountOption = str
 _MountOptions = List[_MountOption]
 
 
-def inject_extra_labels_to_alert_rules(rules: dict, extra_alert_labels: dict) -> dict:
-    """Return a copy of the rules dict with extra labels injected."""
-    result = copy.deepcopy(rules)
-    for item in result.values():
-        for group in item.get("groups", []):
-            for rule in group.get("rules", []):
-                rule.setdefault("labels", {}).update(extra_alert_labels)
-    return result
-
-
 @dataclass
 class _SnapFstabEntry:
     """Representation of an individual fstab entry for snap plugs."""
@@ -352,10 +342,6 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         rules = self._cos.metrics_alerts
         topology = JujuTopology.from_charm(self)
 
-        extra_alert_labels = key_value_pair_string_to_dict(
-            cast(str, self.model.config.get("extra_alert_labels", ""))
-        )
-
         # Get the rules defined by Grafana Agent itself.
         own_rules = AlertRules(query_type="promql", topology=topology)
         own_rules.add_path(METRICS_RULES_SRC_PATH)
@@ -363,9 +349,6 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
             rules[topology.identifier]["groups"] += own_rules.as_dict()["groups"]
         else:
             rules[topology.identifier] = own_rules.as_dict()
-
-        if extra_alert_labels:
-            rules = inject_extra_labels_to_alert_rules(rules, extra_alert_labels)
 
         return rules
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,12 @@ from cosl.rules import AlertRules
 from ops import main
 from ops.model import BlockedStatus, MaintenanceStatus, Relation
 
-from grafana_agent import CONFIG_PATH, METRICS_RULES_SRC_PATH, GrafanaAgentCharm
+from grafana_agent import (
+    CONFIG_PATH,
+    METRICS_RULES_SRC_PATH,
+    GrafanaAgentCharm,
+    key_value_pair_string_to_dict,
+)
 from snap_management import SnapSpecError, install_ga_snap
 
 logger = logging.getLogger(__name__)
@@ -31,37 +36,6 @@ logger = logging.getLogger(__name__)
 _FsType = str
 _MountOption = str
 _MountOptions = List[_MountOption]
-
-
-def key_value_pair_string_to_dict(key_value_pair: str) -> dict:
-    """Transform a comma-separated key-value pairs into a dict."""
-    result = {}
-
-    for pair in key_value_pair.split(","):
-        pair = pair.strip()
-        if not pair:
-            continue
-
-        if ":" in pair:
-            sep = ":"
-        elif "=" in pair:
-            sep = "="
-        else:
-            logger.error("Invalid pair without separator ':' or '=': '%s'", pair)
-            continue
-
-        key, value = map(str.strip, pair.split(sep, 1))
-
-        if not key:
-            logger.error("Empty key in pair: '%s'", pair)
-            continue
-        if not value:
-            logger.error("Empty value in pair: '%s'", pair)
-            continue
-
-        result[key] = value
-
-    return result
 
 
 def inject_extra_labels_to_alert_rules(rules: dict, extra_alert_labels: dict) -> dict:

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,14 +5,13 @@
 
 """A  juju charm for Grafana Agent on Kubernetes."""
 
-import copy
 import logging
 import os
 import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union, cast, get_args
+from typing import Any, Dict, List, Optional, Set, Union, get_args
 
 import yaml
 from charms.grafana_agent.v0.cos_agent import COSAgentRequirer, ReceiverProtocol
@@ -27,7 +26,6 @@ from grafana_agent import (
     CONFIG_PATH,
     METRICS_RULES_SRC_PATH,
     GrafanaAgentCharm,
-    key_value_pair_string_to_dict,
 )
 from snap_management import SnapSpecError, install_ga_snap
 

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -57,6 +57,37 @@ DASHBOARDS_DEST_PATH = "grafana_dashboards"  # placeholder until we figure out t
 RulesMapping = namedtuple("RulesMapping", ["src", "dest"])
 
 
+def key_value_pair_string_to_dict(key_value_pair: str) -> dict:
+    """Transform a comma-separated key-value pairs into a dict."""
+    result = {}
+
+    for pair in key_value_pair.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+
+        if ":" in pair:
+            sep = ":"
+        elif "=" in pair:
+            sep = "="
+        else:
+            logger.error("Invalid pair without separator ':' or '=': '%s'", pair)
+            continue
+
+        key, value = map(str.strip, pair.split(sep, 1))
+
+        if not key:
+            logger.error("Empty key in pair: '%s'", pair)
+            continue
+        if not value:
+            logger.error("Empty value in pair: '%s'", pair)
+            continue
+
+        result[key] = value
+
+    return result
+
+
 class GrafanaAgentReloadError(Exception):
     """Custom exception to indicate that grafana agent config couldn't be reloaded."""
 
@@ -153,11 +184,15 @@ class GrafanaAgentCharm(CharmBase):
                 shutil.copytree(rules.src, rules.dest, dirs_exist_ok=True)
 
         alert_rules_path = self.metrics_rules_paths.dest
+        extra_alert_labels = key_value_pair_string_to_dict(
+            cast(str, self.model.config.get("extra_alert_labels", ""))
+        )
         self._remote_write = PrometheusRemoteWriteConsumer(
             self,
             alert_rules_path=alert_rules_path,
             forward_alert_rules=self._forward_alert_rules,
             refresh_event=[self.on.config_changed],
+            extra_alert_labels=extra_alert_labels,
         )
 
         self._loki_consumer = LokiPushApiConsumer(

--- a/tests/unit/test_alert_labels.py
+++ b/tests/unit/test_alert_labels.py
@@ -179,7 +179,6 @@ def test_extra_alerts_config():
 
     for group in alert_rules["groups"]:
         for rule in group["rules"]:
-            print(f"+++ Rule group: {rule}")
             assert rule["labels"]["environment"] == "PRODUCTION"
             assert rule["labels"]["zone"] == "Mars"
             if "grafana_agent_alertgroup_alerts" in group["name"]:

--- a/tests/unit/test_alert_labels.py
+++ b/tests/unit/test_alert_labels.py
@@ -179,9 +179,9 @@ def test_extra_alerts_config():
 
     for group in alert_rules["groups"]:
         for rule in group["rules"]:
+            assert rule["labels"]["environment"] == "PRODUCTION"
+            assert rule["labels"]["zone"] == "Mars"
             if "grafana_agent_alertgroup_alerts" in group["name"]:
-                assert rule["labels"]["environment"] == "PRODUCTION"
-                assert rule["labels"]["zone"] == "Mars"
                 assert (
                     rule["labels"]["juju_application"] == "primary"
                     or rule["labels"]["juju_application"] == "subordinate"

--- a/tests/unit/test_alert_labels.py
+++ b/tests/unit/test_alert_labels.py
@@ -36,9 +36,7 @@ cos_agent_primary_data = {
                 "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQAmCnsKICAidGl0bGUiOiAi"
                 "Zm9vIiwKICAiYmFyIiA6ICJiYXoiCn0KAACkcc0YFt15xAABPyd8KlLdH7bzfQEAAAAABFla"
             ],
-            "metrics_scrape_jobs": [
-                {"job_name": "primary_0", "path": "/metrics", "port": "8080"}
-            ],
+            "metrics_scrape_jobs": [{"job_name": "primary_0", "path": "/metrics", "port": "8080"}],
             "log_slots": ["foo:bar"],
         }
     )
@@ -139,7 +137,9 @@ def test_extra_alerts_config():
     # GIVEN a new key-value pair of extra alerts labels, for instance:
     # juju config agent extra_alerts_labels="environment: PRODUCTION, zone=Mars"
 
-    config1 = {"extra_alert_labels": "environment: PRODUCTION, zone=Mars",}
+    config1 = {
+        "extra_alert_labels": "environment: PRODUCTION, zone=Mars",
+    }
 
     # THEN The extra_alert_labels MUST be added to the alert rules.
     cos_agent_primary_relation = SubordinateRelation(
@@ -161,7 +161,7 @@ def test_extra_alerts_config():
             remote_write_relation,
             PeerRelation("peers"),
         ],
-        config=config1, # type: ignore
+        config=config1,  # type: ignore
     )
 
     state_0 = ctx.run(ctx.on.relation_changed(relation=cos_agent_primary_relation), state)
@@ -179,6 +179,7 @@ def test_extra_alerts_config():
 
     for group in alert_rules["groups"]:
         for rule in group["rules"]:
+            print(f"+++ Rule group: {rule}")
             assert rule["labels"]["environment"] == "PRODUCTION"
             assert rule["labels"]["zone"] == "Mars"
             if "grafana_agent_alertgroup_alerts" in group["name"]:
@@ -186,8 +187,6 @@ def test_extra_alerts_config():
                     rule["labels"]["juju_application"] == "primary"
                     or rule["labels"]["juju_application"] == "subordinate"
                 )
-
-
 
     # GIVEN the config option for extra alert labels is unset
     config2 = {}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
As part of `Backport the extra_alert_labels feature to track/1` and other similar issues, we added a new config option for extra alert labels, but those labels are not being added to the [generic alert rules](https://github.com/canonical/cos-lib/blob/6cd3769727419f50018994591a90c0024542389b/src/cosl/rules.py#L114).

~~This is likely because in grafana-agent, we do not pass the `extra_alert_labels` to [the cos-agent lib which is handling the generic alert rules](https://github.com/canonical/grafana-agent-operator/blob/7684e2340f538ec42cd3e0d0be253a43c645058c/src/charm.py#L228). This would likely need to be done for other places we inject generic alerts like in [prom-remote-write](https://github.com/canonical/grafana-agent-operator/blob/7684e2340f538ec42cd3e0d0be253a43c645058c/src/grafana_agent.py#L156) and prometheus scrape.~~

The problem is that we are adding the `extra_alert_labels` before sending the rules to Prometheus. This means that the generic alert rules produced for grafana agent itself won't get those extra alert labels.

## Solution

Add a way to specify extra alert labels in the `PrometheusRemoteWriteConsumer` library, so that the injected generic alert rules also have those labels.

Note that the alerts coming from principals (e.g. Zookeeper) are now not injected with extra alert labels by the charm code: those are added only when being sent to Prometheus, in the library code.

The unit test coverage has been expanded to cover this scenario.

## Drive-by fixes

- `charmcraft fetch-lib`

---

Don't merge until a tandem PR in Prometheus is merged for the charm library:
- https://github.com/canonical/prometheus-k8s-operator/pull/714