### PR TITLE
feat: add custom check on tracing ready in cos-agent

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -254,7 +254,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 21
+LIBPATCH = 22
 
 PYDEPS = ["cosl >= 0.0.50", "pydantic"]
 
@@ -923,6 +923,7 @@ class COSAgentRequirer(Object):
         relation_name: str = DEFAULT_RELATION_NAME,
         peer_relation_name: str = DEFAULT_PEER_RELATION_NAME,
         refresh_events: Optional[List[str]] = None,
+        is_tracing_ready: Optional[Callable] = None,
     ):
         """Create a COSAgentRequirer instance.
 
@@ -937,6 +938,9 @@ class COSAgentRequirer(Object):
         self._relation_name = relation_name
         self._peer_relation_name = peer_relation_name
         self._refresh_events = refresh_events or [self._charm.on.config_changed]
+        self._is_tracing_ready = self._charm.tracing.is_ready  # type: ignore
+        if is_tracing_ready:
+            self._is_tracing_ready = is_tracing_ready
 
         events = self._charm.on[relation_name]
         self.framework.observe(
@@ -1059,7 +1063,7 @@ class COSAgentRequirer(Object):
                             # databag contents (as it expects a string in URL) but that won't cause any errors as
                             # tracing endpoints are the only content in the grafana-agent's side of the databag.
                             url=f"{self._get_tracing_receiver_url(protocol)}"
-                            if self._charm.tracing.is_ready()  # type: ignore
+                            if self._is_tracing_ready()
                             else None,
                             protocol=ProtocolType(
                                 name=protocol,


### PR DESCRIPTION
## Issue
The COS Agent library is used both by OpenTelemetry Collector and Grafana Agent. Unfortunately, the `CosAgentRequirer` is tightly coupled to the Grafana Agent charm.

An unofficial and unwritten requirement for tracing in grafana-agent is that a relation to receive traces **also requires an outgoing relation to send traces to Tempo**. This is required for grafana-agent to function; otelcol has a debug exporter, and thus it doesn't need an outgoing relation to Tempo for traces to be ingested.

The COS Agent library checks the relation object that manages sending traces to Tempo (by calling `tracing.is_ready`) before sending the "traces receiver url" to the principal.

This silent failure mode isn't detected anywhere.


## Solution
Add the possibility to specify a custom function to check for tracing readiness; otelcol will always pass `True`, because the tracing receiver is always enabled. The default behavior is preserverd for grafana-agent.

We're passing a `Callable` instead of a `bool` to lazily evaluate tracing being ready.

