### PR TITLE
chore: pin TF Juju provider to version = "< 1.0.0"

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,35 +3,39 @@
 
 This is a Terraform module facilitating the deployment of grafana-agent charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
-
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
-This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
-## API
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | < 1.0.0 |
 
-### Inputs
-The module offers the following configurable inputs:
+## Providers
 
-| Name | Type | Description | Required |
-| - | - | - | - |
-| `app_name`| string | Application name | mimir-worker |
-| `channel`| string | Channel that the charm is deployed from | latest/edge |
-| `config`| map(any) | Map of the charm configuration options | {} |
-| `constraints`| string | Constraints for the Juju deployment| "" |
-| `model_name`| string | Name of the model that the charm is deployed on |  |
-| `revision`| number | Revision number of the charm name | null |
-| `units`| number | Number of units to deploy | 1 |
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | < 1.0.0 |
 
-### Outputs
-Upon applied, the module exports the following outputs:
+## Modules
+
+No modules.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Application name | `string` | n/a | yes |
+| <a name="input_channel"></a> [channel](#input\_channel) | Charm channel | `string` | `"latest/stable"` | no |
+| <a name="input_config"></a> [config](#input\_config) | Config options as in the ones we pass in juju config | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | Constraints to be applied | `string` | `""` | no |
+| <a name="input_model_name"></a> [model\_name](#input\_model\_name) | Model name | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Charm revision | `number` | `null` | no |
+| <a name="input_units"></a> [units](#input\_units) | Number of units | `number` | `1` | no |
+
+## Outputs
 
 | Name | Description |
-| - | - |
-| `app_name`|  Application name |
-| `requires`|  Map of `requires` endpoints |
-
-## Usage
-
-Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
-
-To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.15.0"
+      version = "< 1.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR pins the TF provider for the root module and submodules to `version = "< 1.0.0"` so that we can tag this repo for users to always be able to source our modules for TF Juju provider `< v1`. See [this tracking issue](https://github.com/canonical/observability-stack/issues/135) for details.