### PR TITLE
Exclude k8s CSI mountpoints from disk usage monitoring 

### DIFF
--- a/src/prometheus_alert_rules/disk.rules
+++ b/src/prometheus_alert_rules/disk.rules
@@ -20,7 +20,7 @@ groups:
         The 6-hour-ahead prediction is made as a linear regression from the last 60 minutes of data.
   - alert: HostDiskSpace
     # some fstype are excluded because they are not relevant; see https://github.com/canonical/grafana-agent-operator/pull/233 for details
-    expr: used_disk_space{fstype!~"fuse\\.lxcfs|fuse\\.snapfuse", mountpoint!~"/run.*|/proc|/dev"} > 90
+    expr: used_disk_space{fstype!~"fuse\\.lxcfs|fuse\\.snapfuse", mountpoint!~"/run.*|/proc|/dev|/var/lib/kubelet/plugins/kubernetes.io/csi/.*"} > 90
     for: 0m
     labels:
       severity: critical


### PR DESCRIPTION
## Issue
This fixes [279](https://github.com/canonical/grafana-agent-operator/issues/279).
Filesystems mounted under /var/lib/kubelet/plugins/kubernetes.io/csi/ are excluded from disk usage monitoring.


## Solution
The updated rules prevent mountpoints inside `/var/lib/kubelet/plugins/kubernetes.io/csi/` from producing `HostDiskSpace` alerts.
The mountpoints at other locations keep producing alerts.


## Context
This fix was requested in issue [279](https://github.com/canonical/grafana-agent-operator/issues/279) in order to suppress non significant alerts.


## Testing Instructions
Install the `grafana-agent` charm and integrate it with the `zookeeper` charm or any other charm supporting the `grafana-agent`.

Create two mountpoints and fill them at 91%:

- `fs_to_ignore`, mounted at `/var/lib/kubelet/plugins/kubernetes.io/csi/csi_fs`. This filesystem will not produce `HostDiskSpace` alerts with the updated rule:
```bash
sudo mkdir -p /var/lib/kubelet/plugins/kubernetes.io/csi/csi_fs
sudo mount -t tmpfs -o size=1000M fs_to_ignore /var/lib/kubelet/plugins/kubernetes.io/csi/csi_fs
sudo fallocate -l 910M /var/lib/kubelet/plugins/kubernetes.io/csi/csi_fs/bigfile

```
- `fs_to_monitor`, mounted at `/var/lib/kubelet/plugins/kubernetes.io/monitored_path`. This filesystem will produce a `HostDiskSpace` alert with the updated rule.
```bash
sudo mkdir -p /var/lib/kubelet/plugins/kubernetes.io/monitored_path/
sudo mount -t tmpfs -o size=1000M fs_to_monitor /var/lib/kubelet/plugins/kubernetes.io/monitored_path/
sudo fallocate -l 910M /var/lib/kubelet/plugins/kubernetes.io/monitored_path/bigfile

```

### Expected results

Before: both mountpoints produce alerts when at 91% disk usage.
<img width="1903" height="507" alt="before-both-fs-alerted" src="https://github.com/user-attachments/assets/7565000a-5c7d-4bd8-b528-831a5196f14e" />

After: only `fs_to_monitor` produces an alert when at 91% disk usage, `fs_to_ignore` does not.
<img width="1907" height="462" alt="after-only-monitored-fs-alerted" src="https://github.com/user-attachments/assets/f8436bc5-4268-4e86-a8f0-783b9ba796c1" />
