### PR TITLE
chore: implement new prometheus remote write requirements

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -193,6 +193,7 @@ class GrafanaAgentCharm(CharmBase):
             forward_alert_rules=self._forward_alert_rules,
             refresh_event=[self.on.config_changed],
             extra_alert_labels=extra_alert_labels,
+            peer_relation_name="peers",
         )
 
         self._loki_consumer = LokiPushApiConsumer(

--- a/tests/unit/test_peer_relation.py
+++ b/tests/unit/test_peer_relation.py
@@ -65,7 +65,7 @@ class MyRequirerCharm(CharmBase):
     def __init__(self, framework: Framework):
         super().__init__(framework)
         self.cosagent = COSAgentRequirer(self)
-        self.prom = PrometheusRemoteWriteConsumer(self)
+        self.prom = PrometheusRemoteWriteConsumer(self, peer_relation_name="peers")
         self.tracing = MagicMock()
         framework.observe(self.cosagent.on.data_changed, self._on_cosagent_data_changed)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8, <4"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.3.2"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
@@ -939,9 +939,9 @@ dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/b3/bd83f017c73044a221bc0c7ad62f583d11d1276190f65eb1c086150e24e4/cosl-1.3.2.tar.gz", hash = "sha256:dea8e937629b44232bb306f76fbf88064a1a0093fe66dacdd43ab2cb06b7f35f", size = 46029, upload-time = "2025-11-20T22:03:14.031Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/de/c41b6308ce2a6a1523fe1d5cebb831ad779e55008f8d8c0c724fccc4b407/cosl-1.4.0.tar.gz", hash = "sha256:eb6ebf682f76eec24e3c9759fb6fe5185660fcf7bb3dd8adc42e5a74816c8615", size = 46191, upload-time = "2025-11-25T17:16:01.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/e2/d10330cce5be3d8842d3a8889ed368546a2fa41b701c1abb56b0bf9b59f2/cosl-1.3.2-py3-none-any.whl", hash = "sha256:52ca0983fb0bf3bfa8d0bb796fc6a8208a71bbf4481a5c90905b1f71a1184d4b", size = 36598, upload-time = "2025-11-20T22:03:12.736Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9b/716ceb6021530b9cdbbfd681b7f296b660cdc763c365283e82581a71c299/cosl-1.4.0-py3-none-any.whl", hash = "sha256:410042805b17876c19d405ff5bf5c2461a84a7bff389ce3ad928f44e8c09b882", size = 36649, upload-time = "2025-11-25T17:16:00.098Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Tracking issue with further context: https://github.com/canonical/cos-lib/issues/167

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Bumps `cosl` so new generic alert rules (with new descriptions) are used.
2. Fetches charm libs so new changes from Prometheus remote write lib are present (lib patch 11).
3. Passes the name of this charm's peer relation when instantiating `PromtheusRemoteWriteConsumer`.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Pack this charm and relate it to Ubuntu and Prometheus.
2. Scale up Ubuntu to 2.
3. On the Promtheus alerts page, you should now see 2 HostMetricsMissing alerts for Grafana Agent, one per each unit.
<img width="2509" height="1115" alt="image" src="https://github.com/user-attachments/assets/ba80824d-e25e-4be5-b7f7-e82d1f9ea1f2" />
4. If you stop the `grafana-agent` snap in one of them, only that one alert should be triggered. The AggregatorMetricsMissing alert should be unchanged.
<img width="2540" height="898" alt="image" src="https://github.com/user-attachments/assets/10aed4d3-ecbf-495f-88e7-58e019956335" />

5. And if you stop the snap in the other unit, both HostMetricsMissing alerts should be triggered and AggregatorMetricsMissing alert should also be triggered since ALL units of the aggregator are down.

<img width="2543" height="321" alt="image" src="https://github.com/user-attachments/assets/14bfe454-05e7-4061-b46b-fe4f07f28f5c" />

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
