### PR TITLE
chore (track 2): implement new prometheus remote write lib requirements

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -193,6 +193,7 @@ class GrafanaAgentCharm(CharmBase):
             forward_alert_rules=self._forward_alert_rules,
             refresh_event=[self.on.config_changed],
             extra_alert_labels=extra_alert_labels,
+            peer_relation_name="peers",
         )
 
         self._loki_consumer = LokiPushApiConsumer(

--- a/tests/unit/test_peer_relation.py
+++ b/tests/unit/test_peer_relation.py
@@ -65,7 +65,7 @@ class MyRequirerCharm(CharmBase):
     def __init__(self, framework: Framework):
         super().__init__(framework)
         self.cosagent = COSAgentRequirer(self)
-        self.prom = PrometheusRemoteWriteConsumer(self)
+        self.prom = PrometheusRemoteWriteConsumer(self, peer_relation_name="peers")
         self.tracing = MagicMock()
         framework.observe(self.cosagent.on.data_changed, self._on_cosagent_data_changed)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8, <4"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
@@ -939,9 +939,9 @@ dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/8f/df8af203b4546e3f3e8bfd56a88e560be461b3f6f7ae2ffeaf821a3a0c58/cosl-1.3.0.tar.gz", hash = "sha256:d602b22e46dbd2369bd1c88aadf699b1296e8853d8dd39c1e3f63b6839df00fd", size = 45345, upload-time = "2025-10-02T13:44:52.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/de/c41b6308ce2a6a1523fe1d5cebb831ad779e55008f8d8c0c724fccc4b407/cosl-1.4.0.tar.gz", hash = "sha256:eb6ebf682f76eec24e3c9759fb6fe5185660fcf7bb3dd8adc42e5a74816c8615", size = 46191, upload-time = "2025-11-25T17:16:01.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/10/0ff46329321c76c7e55ed861c58fa9a0d12cfbc59982652757711589d053/cosl-1.3.0-py3-none-any.whl", hash = "sha256:6b4f7c8201a58f9e5d593e290e89d91a89db54d5c413d25dfaa799915913db09", size = 36367, upload-time = "2025-10-02T13:44:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9b/716ceb6021530b9cdbbfd681b7f296b660cdc763c365283e82581a71c299/cosl-1.4.0-py3-none-any.whl", hash = "sha256:410042805b17876c19d405ff5bf5c2461a84a7bff389ce3ad928f44e8c09b882", size = 36649, upload-time = "2025-11-25T17:16:00.098Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Tracking issue with further context: https://github.com/canonical/cos-lib/issues/167
This PR is very similar to this PR #343 except this backports that change into track 2.
## Solution
<!-- A summary of the solution addressing the above issue -->
1. Bumps `cosl` so new generic alert rules (with new descriptions) are used.
2. Fetches charm libs so new changes from Prometheus remote write lib are present (lib patch 11).
3. Passes the name of this charm's peer relation when instantiating `PromtheusRemoteWriteConsumer`.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Pack this charm and relate it to Ubuntu and Prometheus.
2. Scale up Ubuntu to 2.
3. On the Promtheus alerts page, you should now see 2 HostMetricsMissing alerts for Grafana Agent, one per each unit.
<img width="2512" height="1189" alt="image" src="https://github.com/user-attachments/assets/0ac13b14-0c62-4bdf-a6ee-fdc3406d7cb3" />
4. If you stop the `grafana-agent` snap in one of them, only that one alert should be triggered. The AggregatorMetricsMissing alert should be unchanged.
<img width="2540" height="898" alt="image" src="https://github.com/user-attachments/assets/10aed4d3-ecbf-495f-88e7-58e019956335" />

5. And if you stop the snap in the other unit, both HostMetricsMissing alerts should be triggered and AggregatorMetricsMissing alert should also be triggered since ALL units of the aggregator are down.

<img width="2514" height="321" alt="image" src="https://github.com/user-attachments/assets/6840a529-4555-45ae-87eb-d838757b355e" />


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
