### PR TITLE
fix: automatically render job_name for metrics_endpoints

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -254,7 +254,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 23
+LIBPATCH = 24
 
 PYDEPS = ["cosl >= 0.0.50", "pydantic"]
 
@@ -711,11 +711,16 @@ class COSAgentProvider(Object):
             scrape_configs = self._scrape_configs.copy()
 
         # Convert "metrics_endpoints" to standard scrape_configs, and add them in
+        unit_name = self._charm.unit.name.replace("/", "_")
         for endpoint in self._metrics_endpoints:
+            port = endpoint["port"]
+            path = endpoint["path"]
+            sanitized_path = path.strip("/").replace("/", "_")
             scrape_configs.append(
                 {
-                    "metrics_path": endpoint["path"],
-                    "static_configs": [{"targets": [f"localhost:{endpoint['port']}"]}],
+                    "job_name": f"{unit_name}_localhost_{port}_{sanitized_path}",
+                    "metrics_path": path,
+                    "static_configs": [{"targets": [f"localhost:{port}"]}],
                 }
             )
 


### PR DESCRIPTION
This PR is a cherry-pick of #371 to track 2.
