### PR TITLE
fix: Always set a `job_name` for all scrape_configs

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -712,20 +712,21 @@ class COSAgentProvider(Object):
             scrape_configs = self._scrape_configs.copy()
 
         # Convert "metrics_endpoints" to standard scrape_configs, and add them in
-        unit_name = self._charm.unit.name.replace("/", "_")
         for endpoint in self._metrics_endpoints:
-            port = endpoint["port"]
-            path = endpoint["path"]
-            sanitized_path = path.strip("/").replace("/", "_")
             scrape_configs.append(
                 {
-                    "job_name": f"{unit_name}_localhost_{port}_{sanitized_path}",
-                    "metrics_path": path,
-                    "static_configs": [{"targets": [f"localhost:{port}"]}],
+                    "metrics_path": endpoint["path"],
+                    "static_configs": [{"targets": [f"localhost:{endpoint['port']}"]}],
                 }
             )
 
         scrape_configs = scrape_configs or []
+
+        # Augment job name to include the app name and a unique id (index)
+        for idx, scrape_config in enumerate(scrape_configs):
+            scrape_config["job_name"] = "_".join(
+                [self._charm.app.name, str(idx), scrape_config.get("job_name", "default")]
+            )
 
         return scrape_configs
 

--- a/tests/unit/test_cos_agent_e2e.py
+++ b/tests/unit/test_cos_agent_e2e.py
@@ -76,7 +76,7 @@ class PrincipalProvider(CharmBase):
 
 
 class BadPrincipalProvider(PrincipalProvider):
-    _log_slots = 'charmed:oops-a-str-not-a-list'  # type: ignore
+    _log_slots = "charmed:oops-a-str-not-a-list"  # type: ignore
 
 
 REQUIRER_META = {
@@ -112,31 +112,42 @@ def test_cos_agent_injects_generic_alerts():
     config = json.loads(
         state_out.get_relation(cos_agent.id).local_unit_data[CosAgentPeersUnitData.KEY]
     )
+
     # THEN the metrics_alert_rules groups should only contain the generic alert groups
     # NOTE: that we cannot simply test equality with generic_alert_groups since
     #       the name and labels are injected too
     def names_and_exprs(rules):
         return {(r["alert"], r["expr"]) for g in rules["groups"] for r in g["rules"]}
-    assert (
-        names_and_exprs(config["metrics_alert_rules"]) == names_and_exprs(generic_alert_groups.application_rules)
+
+    assert names_and_exprs(config["metrics_alert_rules"]) == names_and_exprs(
+        generic_alert_groups.application_rules
     )
 
 
-@pytest.mark.parametrize("path,port,expected", [
-    ("/metrics", 8080, "default"),
-    ("/metrics/", 8080, "default"),
-    ("/sub/metrics", 8080, "default"),
-])
+@pytest.mark.parametrize(
+    "path,port,expected",
+    [
+        ("/metrics", 8080, "default"),
+        ("/metrics/", 8080, "default"),
+        ("/sub/metrics", 8080, "default"),
+    ],
+)
 def test_cos_agent_renders_job_name_for_metrics_endpoints(path, port, expected):
     # GIVEN a principal charm specified some metrics endpoint (not scrape jobs)
     class SomeProvider(CharmBase):
-
         def __init__(self, framework: Framework):
             super().__init__(framework)
             self.gagent = COSAgentProvider(
                 self,
                 metrics_endpoints=[
                     {"path": path, "port": port},
+                ],
+                scrape_configs=[
+                    {
+                        "metrics_path": "/metrics",
+                        "static_configs": [{"targets": ["foo:8008"]}],
+                        "scheme": "http",
+                    }
                 ],
             )
 
@@ -155,13 +166,26 @@ def test_cos_agent_renders_job_name_for_metrics_endpoints(path, port, expected):
     )
 
     # THEN a scrape job is rendered
-    assert len(config['metrics_scrape_jobs']) == 1
+    assert config["metrics_scrape_jobs"] == [
+        {
+            "metrics_path": "/metrics",
+            "static_configs": [{"targets": ["foo:8008"]}],
+            "scheme": "http",
+            # AND the job name is rendered automatically
+            "job_name": "mock-principal_0_default",
+        },
+        {
+            "metrics_path": path,
+            "static_configs": [{"targets": [f"localhost:{port}"]}],
+            # AND the job name is rendered automatically
+            "job_name": "mock-principal_1_default",
+        },
+    ]
 
-    # AND the job name is rendered automatically from the paths and ports provided
-    job_dict = config['metrics_scrape_jobs'][0]
-    assert "job_name" in job_dict
-    # AND scrape spec is part of the job name
-    assert job_dict["job_name"].endswith(expected)
+    for job in config["metrics_scrape_jobs"]:
+        assert "job_name" in job
+        # AND scrape spec is part of the job name
+        assert job["job_name"].endswith(expected)
 
 
 def test_cos_agent_changed_no_remote_data():

--- a/tests/unit/test_cos_agent_e2e.py
+++ b/tests/unit/test_cos_agent_e2e.py
@@ -123,9 +123,9 @@ def test_cos_agent_injects_generic_alerts():
 
 
 @pytest.mark.parametrize("path,port,expected", [
-    ("/metrics", 8080, "localhost_8080_metrics"),
-    ("/metrics/", 8080, "localhost_8080_metrics"),
-    ("/sub/metrics", 8080, "localhost_8080_sub_metrics"),
+    ("/metrics", 8080, "default"),
+    ("/metrics/", 8080, "default"),
+    ("/sub/metrics", 8080, "default"),
 ])
 def test_cos_agent_renders_job_name_for_metrics_endpoints(path, port, expected):
     # GIVEN a principal charm specified some metrics endpoint (not scrape jobs)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
[This PR](https://github.com/canonical/grafana-agent-operator/pull/371) attempted (only partially fixes it) to fix the regression caused in this PR:
- https://github.com/canonical/grafana-agent-operator/pull/328
- Versions `0.23` (released `Dec 12, 2025`) and `0.24` (released `Feb 5, 2026`) are broken.

Fixes partially https://github.com/canonical/grafana-agent-operator/issues/382 and https://github.com/canonical/postgresql-operator/issues/1469

## Solution
<!-- A summary of the solution addressing the above issue -->

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [x] Announcement on discourse
- [x] Courtesy reach out on MM
- [x] Test with Postgresql (metrics endpoint) and scrape-configs

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
### Unit
I added `scrape_configs` to the `COSAgentProvider` in the unit test and assert that the `job_name`(s) are rendered in `scrape_configs` **and** `._metrics_endpoints`.

### Manual
I deployed 2 versions of `postgresql`: `pg` (fixed) and `pg-two` (packed from `main`) both related to `prw`:
<img width="816" height="381" alt="image" src="https://github.com/user-attachments/assets/f00aba7e-b0ac-4f09-92ab-1d25eccb0bd1" />

when I check the snap logs and the snap status, you can see that the PG from `main` is failing, as identified in the original issue, but the PG with my fix works:

<img width="1798" height="503" alt="Screenshot from 2026-02-23 09-37-12" src="https://github.com/user-attachments/assets/c85e754d-e780-4f8e-9d2a-b1df6798e23e" />

We are adding hashing logic to the `job_name`. Here is some tests that I ran:
#### Summary
- `pg_0_default` -> `pg_default_822aba33`
- `pg_1_default` -> `pg_default_df1fc737`
- `pg_2_default` -> `pg_default_eab4104d`
#### Pre-regression functionality in postgresql
```yaml
scrape_configs:
- job_name: pg_0_default
  metrics_path: /metrics
  scheme: http
  static_configs:
  - labels:
	  juju_application: pg
	  juju_model: leon
	  juju_model_uuid: edfb9ab2-1e23-45a1-819e-eba160357525
	  juju_unit: pg/1
	targets:
	- 10.238.4.136:8008
  tls_config:
	insecure_skip_verify: true
- job_name: pg_1_default
  metrics_path: /metrics
  static_configs:
  - labels:
	  juju_application: pg
	  juju_model: leon
	  juju_model_uuid: edfb9ab2-1e23-45a1-819e-eba160357525
	  juju_unit: pg/1
	targets:
	- localhost:9187
- job_name: pg_2_default
  metrics_path: /metrics
  static_configs:
  - labels:
	  juju_application: pg
	  juju_model: leon
	  juju_model_uuid: edfb9ab2-1e23-45a1-819e-eba160357525
	  juju_unit: pg/1
	targets:
	- localhost:9854
```
#### New functionality in `cos_agent` `0.25`
```yaml
scrape_configs:
- job_name: pg_default_822aba33
  metrics_path: /metrics
  static_configs:
  - labels:
	  juju_application: pg
	  juju_model: leon
	  juju_model_uuid: edfb9ab2-1e23-45a1-819e-eba160357525
	  juju_unit: pg/1
	targets:
	- localhost:9187
- job_name: pg_default_df1fc737
  metrics_path: /metrics
  scheme: http
  static_configs:
  - labels:
	  juju_application: pg
	  juju_model: leon
	  juju_model_uuid: edfb9ab2-1e23-45a1-819e-eba160357525
	  juju_unit: pg/1
	targets:
	- 10.238.4.136:8008
  tls_config:
	insecure_skip_verify: true
- job_name: pg_default_eab4104d
  metrics_path: /metrics
  static_configs:
  - labels:
	  juju_application: pg
	  juju_model: leon
	  juju_model_uuid: edfb9ab2-1e23-45a1-819e-eba160357525
	  juju_unit: pg/1
	targets:
	- localhost:9854
```

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
Versions `0.23` (released `Dec 12, 2025`) and `0.24` (released `Feb 5, 2026`) of the `cos_agent` lib are broken. Users need to `charmcraft fetch-lib` to obtain a fixed `cos_agent` lib in their charms.