### PR TITLE
fix: fixes gagent panic on loki relation

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -1040,40 +1040,10 @@ class GrafanaAgentCharm(CharmBase):
         Returns:
             a dict with Loki config
         """
-        endpoints = self._loki_endpoints_with_tls()
-
-        configs = []
+        configs: List[Dict[str, Any]] = []
         if self._loki_consumer.loki_endpoints or self._cloud.loki_ready:
-            configs.append(
-                {
-                    "name": "push_api_server",
-                    "clients": endpoints,
-                    "scrape_configs": [
-                        {
-                            "job_name": "loki",
-                            "loki_push_api": {
-                                "server": {
-                                    "http_listen_port": self._http_listen_port,
-                                    "grpc_listen_port": self._grpc_listen_port,
-                                },
-                            },
-                        }
-                    ],
-                }
-            )
+            configs = self._additional_log_configs
 
-        if self.cert.enabled:
-            for config in configs:
-                for scrape_config in config.get("scrape_configs", []):
-                    if scrape_config.get("loki_push_api"):
-                        scrape_config["loki_push_api"]["server"]["http_tls_config"] = (
-                            self.tls_config
-                        )
-                        scrape_config["loki_push_api"]["server"]["grpc_tls_config"] = (
-                            self.tls_config
-                        )
-
-        configs.extend(self._additional_log_configs)  # type: ignore
         return (
             {
                 "positions_directory": f"{self.positions_dir()}/grafana-agent-positions",


### PR DESCRIPTION
## Issue
Fixes #379 

## Context
Its a point by reference mistake in the upstream code. basically the `loki_push_api` in the gagent config spins up a http server to receive the logs. [Here is the code for the server spin up](https://github.com/grafana/loki/blob/cef4c2826b4b/clients/pkg/promtail/targets/lokipush/pushtarget.go#L46). It creates a new `PrometheusRegistry` for storing the http servers metrics. Since the servers config is a pointer, on reload it uses the same stale registry to register a new server instance and basically panics because its a duplicate entry. Probably happens mostly only with grafana agent in static mode because thats the only code path that doesnt set its own custom registry


## Solution
Drop the `loki_push_api`  config from the agent configuration entirely as the machine charm has no log receiver endpoints.


## Testing Instructions
Deploy loki
Deploy grafana-agent with ubuntu or zookeeper 
Relate them, and check the agent status

```sh
sudo snap services grafana-agent
```

it should be active and happy