### PR TITLE
fix (track/2): Always set a `job_name` for all scrape_configs

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -211,7 +211,9 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm)
 ```
 """
 
+import copy
 import enum
+import hashlib
 import json
 import logging
 import socket
@@ -254,7 +256,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 24
+LIBPATCH = 25
 
 PYDEPS = ["cosl >= 0.0.50", "pydantic"]
 
@@ -306,6 +308,13 @@ def _dedupe_list(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         if item not in unique_items:
             unique_items.append(item)
     return unique_items
+
+
+def _dict_hash_except_key(scrape_config: Dict[str, Any], key: Optional[str]):
+    """Get a hash of the scrape_config dict, except for the specified key."""
+    cfg_for_hash = {k: v for k, v in scrape_config.items() if k != key}
+    serialized = json.dumps(cfg_for_hash, sort_keys=True)
+    return hashlib.blake2b(serialized.encode(), digest_size=4).hexdigest()
 
 
 class TracingError(Exception):
@@ -697,6 +706,27 @@ class COSAgentProvider(Object):
                 ) as e:
                     logger.error("Invalid relation data provided: %s", e)
 
+    def _deterministic_scrape_configs(
+        self, scrape_configs: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Get deterministic scrape_configs with stable job names.
+
+        For stability across serializations, compute a short per-config hash
+        and append it to the existing job name (or 'default'). Keep the app
+        name as a prefix: <app>_<job_or_default>_<8hex-hash>.
+
+        Hash the whole scrape_config (except any existing job_name) so the
+        suffix is sensitive to all stable fields. Use deterministic JSON
+        serialization.
+        """
+        local_scrape_configs = copy.deepcopy(scrape_configs)
+        for scrape_config in local_scrape_configs:
+            name = scrape_config.get("job_name", "default")
+            short_id = _dict_hash_except_key(scrape_config, "job_name")
+            scrape_config["job_name"] = f"{self._charm.app.name}_{name}_{short_id}"
+
+        return sorted(local_scrape_configs, key=lambda c: c.get("job_name", ""))
+
     @property
     def _scrape_jobs(self) -> List[Dict]:
         """Return a list of scrape_configs.
@@ -711,22 +741,17 @@ class COSAgentProvider(Object):
             scrape_configs = self._scrape_configs.copy()
 
         # Convert "metrics_endpoints" to standard scrape_configs, and add them in
-        unit_name = self._charm.unit.name.replace("/", "_")
         for endpoint in self._metrics_endpoints:
-            port = endpoint["port"]
-            path = endpoint["path"]
-            sanitized_path = path.strip("/").replace("/", "_")
             scrape_configs.append(
                 {
-                    "job_name": f"{unit_name}_localhost_{port}_{sanitized_path}",
-                    "metrics_path": path,
-                    "static_configs": [{"targets": [f"localhost:{port}"]}],
+                    "metrics_path": endpoint["path"],
+                    "static_configs": [{"targets": [f"localhost:{endpoint['port']}"]}],
                 }
             )
 
         scrape_configs = scrape_configs or []
 
-        return scrape_configs
+        return self._deterministic_scrape_configs(scrape_configs)
 
     @property
     def _metrics_alert_rules(self) -> Dict:
@@ -742,7 +767,7 @@ class COSAgentProvider(Object):
         )
         alert_rules.add_path(self._metrics_rules, recursive=self._recursive)
         alert_rules.add(
-            generic_alert_groups.application_rules,
+            copy.deepcopy(generic_alert_groups.application_rules),
             group_name_prefix=JujuTopology.from_charm(self._charm).identifier,
         )
 

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -187,7 +187,6 @@ import tempfile
 import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
-
 import yaml
 from cosl import DashboardPath40UID, LZMABase64
 from cosl.types import type_convert_stored
@@ -218,7 +217,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 46
+LIBPATCH = 48
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -586,9 +585,19 @@ class CharmedDashboard:
                     datasources[template_value["name"]] = template_value["query"].lower()
 
             # Put our own variables in the template
+            # We only want to inject our own dropdowns IFF they are NOT
+            # already in the template coming over relation data.
+            # We'll store all dropdowns in the template from the provider
+            # in a set. We'll add our own if they are not in this set.
+            existing_names = {
+                item.get("name")
+                for item in dict_content["templating"]["list"]
+            }
+
             for d in template_dropdowns:  # type: ignore
-                if d not in dict_content["templating"]["list"]:
+                if d.get("name") not in existing_names:
                     dict_content["templating"]["list"].insert(0, d)
+                    existing_names.add(d.get("name"))
 
         dict_content = cls._replace_template_fields(dict_content, datasources, existing_templates)
         return json.dumps(dict_content)
@@ -1636,29 +1645,60 @@ class GrafanaDashboardConsumer(Object):
             self.on.dashboards_changed.emit()  # pyright: ignore
 
     def _to_external_object(self, relation_id, dashboard):
+        decompressed = LZMABase64.decompress(dashboard["content"])
+        as_dict = json.loads(decompressed)
+
+        dashboard_title = as_dict.get("title", "")
+        dashboard_uid = as_dict.get("uid", "")
+
+        try:
+            dashboard_version = int(as_dict["version"])
+        except (KeyError, ValueError):
+            logger.warning("Dashboard '%s' (uid '%s') is missing a '.version' field or is invalid (must be integer); using '0' as fallback", dashboard_title, dashboard_uid)
+            dashboard_version = 0
+
         return {
             "id": dashboard["original_id"],
             "relation_id": relation_id,
             "charm": dashboard["template"]["charm"],
-            "content": LZMABase64.decompress(dashboard["content"]),
+            "content": decompressed,
+            "dashboard_uid": dashboard_uid,
+            "dashboard_version": dashboard_version,
+            "dashboard_title": dashboard_title,
         }
 
     @property
     def dashboards(self) -> List[Dict]:
         """Get a list of known dashboards across all instances of the monitored relation.
 
+        Filters out dashboards with the same uid, keeping only the one with the highest version.
+        When more than one dashboard have the same uid and version, keep the first one when
+        sorted by (relation_id, content) in reverse lexicographic order (highest relid first).
+
         Returns: a list of known dashboards. The JSON of each of the dashboards is available
             in the `content` field of the corresponding `dict`.
         """
-        dashboards = []
+        d: Dict[str, dict] = {}
 
         for _, (relation_id, dashboards_for_relation) in enumerate(
             self.get_peer_data("dashboards").items()
         ):
             for dashboard in dashboards_for_relation:
-                dashboards.append(self._to_external_object(relation_id, dashboard))
+                obj = self._to_external_object(relation_id, dashboard)
 
-        return dashboards
+                key = obj.get("dashboard_uid")
+                if key is None or str(key).strip() == "":
+                    # At this point, we assume that a `.uid` is present so we do not render a fallback identifier here. Instead, we omit it.
+                    logger.error("dashboard '%s' from relation id '%s' is missing a '.uid' field; omitted", obj["dashboard_title"], obj["relation_id"])
+                    continue
+
+                if key in d:
+                    d[key] = max(d[key], obj, key=lambda o: (o["dashboard_version"], o["relation_id"], o["content"]))
+                    logger.warning("deduplicate dashboard '%s' (uid '%s') - kept version '%s' from relation id '%s'", d[key]["dashboard_title"], d[key]["dashboard_uid"], d[key]["dashboard_version"], d[key]["relation_id"])
+                else:
+                    d[key] = obj
+
+        return list(d.values())
 
     def _get_stored_dashboards(self, relation_id: int) -> list:
         """Pull stored dashboards out of the peer data bucket."""

--- a/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -4,233 +4,11 @@
 
 """This charm library contains utilities to instrument your Charm with opentelemetry tracing data collection.
 
-(yes! charm code, not workload code!)
+WARNING this library is deprecated and will be discontinued in 27.04.
+Instead, please use the new `ops[tracing]` library.
 
-This means that, if your charm is related to, for example, COS' Tempo charm, you will be able to inspect
-in real time from the Grafana dashboard the execution flow of your charm.
-
-# Quickstart
-Fetch the following charm libs:
-
-    charmcraft fetch-lib charms.tempo_coordinator_k8s.v0.tracing
-    charmcraft fetch-lib charms.tempo_coordinator_k8s.v0.charm_tracing
-
-Then edit your charm code to include:
-
-```python
-# import the necessary charm libs
-from charms.tempo_coordinator_k8s.v0.tracing import (
-    TracingEndpointRequirer,
-    charm_tracing_config,
-)
-from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing
-
-
-# decorate your charm class with charm_tracing:
-@charm_tracing(
-    # forward-declare the instance attributes that the instrumentor will look up to obtain the
-    # tempo endpoint and server certificate
-    tracing_endpoint="tracing_endpoint",
-    server_cert="server_cert",
-)
-class MyCharm(CharmBase):
-    _path_to_cert = "/path/to/cert.crt"
-    # path to cert file **in the charm container**. Its presence will be used to determine whether
-    # the charm is ready to use tls for encrypting charm traces. If your charm does not support tls,
-    # you can ignore this and pass None to charm_tracing_config.
-    # If you do support TLS, you'll need to make sure that the server cert is copied to this location
-    # and kept up to date so the instrumentor can use it.
-
-    def __init__(self, framework):
-        # ...
-        self.tracing = TracingEndpointRequirer(self)
-        self.tracing_endpoint, self.server_cert = charm_tracing_config(
-            self.tracing, self._path_to_cert
-        )
-```
-
-# Detailed usage
-To use this library, you need to do two things:
-1) decorate your charm class with
-
-`@trace_charm(tracing_endpoint="my_tracing_endpoint")`
-
-2) add to your charm a "my_tracing_endpoint" (you can name this attribute whatever you like)
-**property**, **method** or **instance attribute** that returns an otlp http/https endpoint url.
-If you are using the ``charms.tempo_coordinator_k8s.v0.tracing.TracingEndpointRequirer`` as
-``self.tracing = TracingEndpointRequirer(self)``, the implementation could be:
-
-```
-    @property
-    def my_tracing_endpoint(self) -> Optional[str]:
-        '''Tempo endpoint for charm tracing'''
-        if self.tracing.is_ready():
-            return self.tracing.get_endpoint("otlp_http")
-        else:
-            return None
-```
-
-At this point your charm will be automatically instrumented so that:
-- charm execution starts a trace, containing
-    - every event as a span (including custom events)
-    - every charm method call (except dunders) as a span
-
-We recommend that you scale up your tracing provider and relate it to an ingress so that your tracing requests
-go through the ingress and get load balanced across all units. Otherwise, if the provider's leader goes down, your tracing goes down.
-
-
-## TLS support
-If your charm integrates with a TLS provider which is also trusted by the tracing provider (the Tempo charm),
-you can configure ``charm_tracing`` to use TLS by passing a ``server_cert`` parameter to the decorator.
-
-If your charm is not trusting the same CA as the Tempo endpoint it is sending traces to,
-you'll need to implement a cert-transfer relation to obtain the CA certificate from the same
-CA that Tempo is using.
-
-For example:
-```
-from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
-@trace_charm(
-    tracing_endpoint="my_tracing_endpoint",
-    server_cert="_server_cert"
-)
-class MyCharm(CharmBase):
-    self._server_cert = "/path/to/server.crt"
-    ...
-
-    def on_tls_changed(self, e) -> Optional[str]:
-        # update the server cert on the charm container for charm tracing
-        Path(self._server_cert).write_text(self.get_server_cert())
-
-    def on_tls_broken(self, e) -> Optional[str]:
-        # remove the server cert so charm_tracing won't try to use tls anymore
-        Path(self._server_cert).unlink()
-```
-
-
-## More fine-grained manual instrumentation
-if you wish to add more spans to the trace, you can do so by getting a hold of the tracer like so:
-```
-import opentelemetry
-...
-def get_tracer(self) -> opentelemetry.trace.Tracer:
-    return opentelemetry.trace.get_tracer(type(self).__name__)
-```
-
-By default, the tracer is named after the charm type. If you wish to override that, you can pass
-a different ``service_name`` argument to ``trace_charm``.
-
-See the official opentelemetry Python SDK documentation for usage:
-https://opentelemetry-python.readthedocs.io/en/latest/
-
-
-## Caching traces
-The `trace_charm` machinery will buffer any traces collected during charm execution and store them
-to a file on the charm container until a tracing backend becomes available. At that point, it will
-flush them to the tracing receiver.
-
-By default, the buffer is configured to start dropping old traces if any of these conditions apply:
-
-- the storage size exceeds 10 MiB
-- the number of buffered events exceeds 100
-
-You can configure this by, for example:
-
-```python
-@trace_charm(
-    tracing_endpoint="my_tracing_endpoint",
-    server_cert="_server_cert",
-    # only cache up to 42 events
-    buffer_max_events=42,
-    # only cache up to 42 MiB
-    buffer_max_size_mib=42,  # minimum 10!
-)
-class MyCharm(CharmBase):
-    ...
-```
-
-Note that setting `buffer_max_events` to 0 will effectively disable the buffer.
-
-The path of the buffer file is by default in the charm's execution root, which for k8s charms means
-that in case of pod churn, the cache will be lost. The recommended solution is to use an existing storage
-(or add a new one) such as:
-
-```yaml
-storage:
-  data:
-    type: filesystem
-    location: /charm-traces
-```
-
-and then configure the `@trace_charm` decorator to use it as path for storing the buffer:
-```python
-@trace_charm(
-    tracing_endpoint="my_tracing_endpoint",
-    server_cert="_server_cert",
-    # store traces to a PVC so they're not lost on pod restart.
-    buffer_path="/charm-traces/buffer.file",
-)
-class MyCharm(CharmBase):
-    ...
-```
-
-## Upgrading from `tempo_k8s.v0`
-
-If you are upgrading from `tempo_k8s.v0.charm_tracing` (note that since then, the charm library moved to
-`tempo_coordinator_k8s.v0.charm_tracing`), you need to take the following steps (assuming you already
-have the newest version of the library in your charm):
-1) If you need the dependency for your tests, add the following dependency to your charm project
-(or, if your project had a dependency on `opentelemetry-exporter-otlp-proto-grpc` only because
-of `charm_tracing` v0, you can replace it with):
-
-`opentelemetry-exporter-otlp-proto-http>=1.21.0`.
-
-2) Update the charm method referenced to from ``@trace`` and ``@trace_charm``,
-to return from ``TracingEndpointRequirer.get_endpoint("otlp_http")`` instead of ``grpc_http``.
-For example:
-
-```
-    from charms.tempo_k8s.v0.charm_tracing import trace_charm
-
-    @trace_charm(
-        tracing_endpoint="my_tracing_endpoint",
-    )
-    class MyCharm(CharmBase):
-
-    ...
-
-        @property
-        def my_tracing_endpoint(self) -> Optional[str]:
-            '''Tempo endpoint for charm tracing'''
-            if self.tracing.is_ready():
-                return self.tracing.otlp_grpc_endpoint() #  OLD API, DEPRECATED.
-            else:
-                return None
-```
-
-needs to be replaced with:
-
-```
-    from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
-
-    @trace_charm(
-        tracing_endpoint="my_tracing_endpoint",
-    )
-    class MyCharm(CharmBase):
-
-    ...
-
-        @property
-        def my_tracing_endpoint(self) -> Optional[str]:
-            '''Tempo endpoint for charm tracing'''
-            if self.tracing.is_ready():
-                return self.tracing.get_endpoint("otlp_http")  # NEW API, use this.
-            else:
-                return None
-```
-
-3) If you were passing a certificate (str) using `server_cert`, you need to change it to
-provide an *absolute* path to the certificate file instead.
+See this migration guide: https://discourse.charmhub.io/t/18076
+See this deprecation announcement: https://discourse.charmhub.io/t/19669
 """
 
 
@@ -341,6 +119,21 @@ from opentelemetry.trace import (
 from ops.charm import CharmBase
 from ops.framework import Framework
 
+
+if os.getenv("CHARM_TRACING_DEPRECATION_NOTICE_DISABLED"):
+    import warnings
+
+    warnings.warn(
+        "The `charm_tracing` library is deprecated and will be discontinued in 27.04. "
+        "Please migrate to the new `ops[tracing]` library. "
+        "See this migration guide: https://discourse.charmhub.io/t/18076 "
+        "See this deprecation announcement: https://discourse.charmhub.io/t/19669 "
+        "To disable this warning, set the CHARM_TRACING_DEPRECATION_NOTICE_DISABLED "
+        "environment variable. ",
+        DeprecationWarning,
+    )
+
+
 # The unique Charmhub library identifier, never change it
 LIBID = "01780f1e588c42c3976d26780fdf9b89"
 
@@ -350,7 +143,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Since `cos_agent` was fixed in:
- https://github.com/canonical/grafana-agent-operator/pull/383

and is released to `0.25` we need to fetch-lib and backport to `track/2`