### PR TITLE
feat(terraform): add channel validation and split outputs

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -39,4 +39,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,22 @@
 output "app_name" {
   value = juju_application.grafana_agent.name
 }
+
+output "provides" {
+  value = {
+    grafana_dashboards_provider = "grafana-dashboards-provider"
+  }
+}
+
+output "requires" {
+  value = {
+    certificates         = "certificates"
+    juju_info            = "juju-info"
+    cos_agent            = "cos-agent"
+    send_remote_write    = "send-remote-write"
+    logging_consumer     = "logging-consumer"
+    grafana_cloud_config = "grafana-cloud-config"
+    receive_ca_cert      = "receive-ca-cert"
+    tracing              = "tracing"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {


### PR DESCRIPTION
Add validation to the  variable in Terraform modules to ensure the  track is used.

Split the  output into separate  and  outputs.

See canonical/alertmanager-k8s-operator#403 and canonical/alertmanager-k8s-operator#396 for reference.