### PR TITLE
feat(terraform): Support for Juju provider v2

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,13 +9,13 @@ This is a Terraform module facilitating the deployment of grafana-agent charm, u
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.0 |
 
 ## Modules
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = ">= 1.0"
     }
   }
 }


### PR DESCRIPTION
## Issue
The TF Juju provider [released 2.0.0](https://github.com/juju/terraform-provider-juju/releases/tag/v2.0.0) on May 26th, 2026 and we need to support this because of the Juju v4 support. This major version is said to not have any breaking changes so we are safe to bump our Juju provider version support:
- `"~> 1.0"` -> `">= 1.0"`

## Solution
- update the Juju provider version to `">= 1.0"`
- rename versions.tf to terraform.tf

## Testing Instructions
See the passing CI in this PR:
- https://github.com/canonical/observability-stack/pull/366

## Upgrade Notes
Users of the product module (deployment modules) can pin the provider version if they want to. We will catch breaking changes in CI when Juju provider releases v3 and we can decide if we want to pin COS 3.0 to `<3` at that point in time.